### PR TITLE
Task/adq 40 remove referencerange observation

### DIFF
--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/ObservationTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/ObservationTransformer.java
@@ -295,7 +295,7 @@ public class ObservationTransformer implements ObservationController.Transformer
       CdwReferenceRanges maybeCdw, CdwCategory cdwCategory) {
     List<CdwCategory.CdwCoding> categoryCoding = cdwCategory.getCoding();
     if (categoryCoding.size() > 0
-        && !StringUtils.isEmpty(categoryCoding.get(0).getCode().value())
+        && (categoryCoding.get(0).getCode() != null)
         && categoryCoding
             .get(0)
             .getCode()

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/ObservationTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/ObservationTransformer.java
@@ -49,6 +49,7 @@ public class ObservationTransformer implements ObservationController.Transformer
      * Specimen reference is omitted since we do not support the a specimen resource and
      * do not want dead links
      */
+
     return Observation.builder()
         .resourceType("Observation")
         .id(cdw.getCdwId())
@@ -64,7 +65,10 @@ public class ObservationTransformer implements ObservationController.Transformer
         .valueCodeableConcept(valueCodeableConcept(cdw.getValueCodeableConcept()))
         .interpretation(interpretation(cdw.getInterpretation()))
         .comments(cdw.getComments())
-        .referenceRange(referenceRanges(cdw.getReferenceRanges()))
+        .referenceRange(
+            (cdw.getCategory().getCoding().get(0).getCode().value().equals(CdwObservationCategoryCode.VITAL_SIGNS.value()))
+                ? null
+                : referenceRanges(cdw.getReferenceRanges()))
         .component(components(cdw.getComponents()))
         .build();
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/ObservationTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/ObservationTransformer.java
@@ -49,7 +49,7 @@ public class ObservationTransformer implements ObservationController.Transformer
      * Specimen reference is omitted since we do not support the a specimen resource and
      * do not want dead links
      */
-
+    String categoryCode = cdw.getCategory().getCoding().get(0).getCode().value();
     return Observation.builder()
         .resourceType("Observation")
         .id(cdw.getCdwId())
@@ -66,7 +66,8 @@ public class ObservationTransformer implements ObservationController.Transformer
         .interpretation(interpretation(cdw.getInterpretation()))
         .comments(cdw.getComments())
         .referenceRange(
-            (cdw.getCategory().getCoding().get(0).getCode().value().equals(CdwObservationCategoryCode.VITAL_SIGNS.value()))
+            (!StringUtils.isEmpty(categoryCode)
+                    && categoryCode.equals(CdwObservationCategoryCode.VITAL_SIGNS.value()))
                 ? null
                 : referenceRanges(cdw.getReferenceRanges()))
         .component(components(cdw.getComponents()))

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/observation/ObservationTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/observation/ObservationTransformerTest.java
@@ -194,9 +194,10 @@ public class ObservationTransformerTest {
 
   @Test
   public void referenceRanges() {
-    assertThat(tx.referenceRanges(null)).isNull();
-    assertThat(tx.referenceRanges(new CdwReferenceRanges())).isNull();
-    assertThat(tx.referenceRanges(cdw.referenceRanges())).isEqualTo(expected.referenceRanges());
+    assertThat(tx.referenceRanges(null, new CdwCategory())).isNull();
+    assertThat(tx.referenceRanges(new CdwReferenceRanges(), new CdwCategory())).isNull();
+    assertThat(tx.referenceRanges(cdw.referenceRanges(), new CdwCategory()))
+        .isEqualTo(expected.referenceRanges());
   }
 
   @Test

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/observation/ObservationTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/observation/ObservationTransformerTest.java
@@ -239,7 +239,8 @@ public class ObservationTransformerTest {
   @Test
   public void vitalSignsReferenceRange() {
     Observation sample = tx.apply(cdw.observationWithCategoryVitalSigns());
-    assertThat(sample.category().coding().get(0).code()).isEqualTo(CdwObservationCategoryCode.VITAL_SIGNS.value());
+    assertThat(sample.category().coding().get(0).code())
+        .isEqualTo(CdwObservationCategoryCode.VITAL_SIGNS.value());
     assertThat(sample.referenceRange()).isEqualTo(null);
   }
 

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/observation/ObservationTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/observation/ObservationTransformerTest.java
@@ -43,6 +43,7 @@ import lombok.SneakyThrows;
 import org.junit.Test;
 
 public class ObservationTransformerTest {
+
   private final ObservationTransformer tx = new ObservationTransformer();
 
   private final CdwSampleData cdw = CdwSampleData.get();
@@ -235,8 +236,16 @@ public class ObservationTransformerTest {
         .isEqualTo(expected.emptyCodeValueQuantity());
   }
 
+  @Test
+  public void vitalSignsReferenceRange() {
+    Observation sample = tx.apply(cdw.observationWithCategoryVitalSigns());
+    assertThat(sample.category().coding().get(0).code()).isEqualTo(CdwObservationCategoryCode.VITAL_SIGNS.value());
+    assertThat(sample.referenceRange()).isEqualTo(null);
+  }
+
   @NoArgsConstructor(staticName = "get", access = AccessLevel.PUBLIC)
   public static class CdwSampleData {
+
     private CdwCategory category() {
       CdwCategory cdw = new CdwCategory();
       cdw.getCoding().add(categoryCoding());
@@ -246,8 +255,8 @@ public class ObservationTransformerTest {
     private CdwCoding categoryCoding() {
       CdwCoding cdw = new CdwCoding();
       cdw.setSystem(CdwObservationCategorySystem.HTTP_HL_7_ORG_FHIR_OBSERVATION_CATEGORY);
-      cdw.setCode(CdwObservationCategoryCode.VITAL_SIGNS);
-      cdw.setDisplay(CdwObservationCategoryDisplay.VITAL_SIGNS);
+      cdw.setCode(CdwObservationCategoryCode.LABORATORY);
+      cdw.setDisplay(CdwObservationCategoryDisplay.LABORATORY);
       return cdw;
     }
 
@@ -387,6 +396,18 @@ public class ObservationTransformerTest {
       return cdw;
     }
 
+    CdwObservation observationWithCategoryVitalSigns() {
+      CdwObservation cdw = observation();
+      CdwCoding cdwCoding = new CdwCoding();
+      cdwCoding.setSystem(CdwObservationCategorySystem.HTTP_HL_7_ORG_FHIR_OBSERVATION_CATEGORY);
+      cdwCoding.setCode(CdwObservationCategoryCode.VITAL_SIGNS);
+      cdwCoding.setDisplay(CdwObservationCategoryDisplay.VITAL_SIGNS);
+      CdwCategory cdwCategory = new CdwCategory();
+      cdwCategory.getCoding().add(cdwCoding);
+      cdw.setCategory(cdwCategory);
+      return cdw;
+    }
+
     CdwObservation observationWithValueCodeableConcept() {
       CdwObservation cdw = observation();
       cdw.setValueCodeableConcept(valueCodeableConcept());
@@ -458,9 +479,10 @@ public class ObservationTransformerTest {
 
   @NoArgsConstructor(staticName = "get")
   public static class Expected {
+
     CodeableConcept category() {
       return codeableConcept(
-          coding("http://hl7.org/fhir/observation-category", "vital-signs", "Vital Signs"));
+          coding("http://hl7.org/fhir/observation-category", "laboratory", "Laboratory"));
     }
 
     CodeableConcept code() {


### PR DESCRIPTION
[ADQ-40](https://vasdvp.atlassian.net/browse/ADQ-40)

* Reference Range is removed if category is 'vital-signs'
* Added Junit to test functionality 

**The db patient is only returning a case with vital-signs so the other case has not been tested. Except by the junit tests.**