### PR TITLE
Fixes page links when count = 0 to just include 'self' link

### DIFF
--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/ConfigurableBaseUrlPageLinks.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/ConfigurableBaseUrlPageLinks.java
@@ -38,15 +38,22 @@ public class ConfigurableBaseUrlPageLinks implements PageLinks {
   public List<BundleLink> create(LinkConfig config) {
     LinkContext context = new LinkContext(config);
     List<BundleLink> links = new LinkedList<>();
-    links.add(context.first());
-    if (context.hasPrevious()) {
-      links.add(context.previous());
+    /*
+     * If recordsPerPage = 0, then only return the self link.
+     */
+    if (!context.isCountOnly()) {
+      links.add(context.first());
+      if (context.hasPrevious()) {
+        links.add(context.previous());
+      }
     }
     links.add(context.self());
-    if (context.hasNext()) {
-      links.add(context.next());
+    if (!context.isCountOnly()) {
+      if (context.hasNext()) {
+        links.add(context.next());
+      }
+      links.add(context.last());
     }
-    links.add(context.last());
     return links;
   }
 
@@ -70,6 +77,10 @@ public class ConfigurableBaseUrlPageLinks implements PageLinks {
 
     boolean hasPrevious() {
       return config.page() > 1 && config.page() <= lastPage();
+    }
+
+    boolean isCountOnly() {
+      return config.recordsPerPage() == 0;
     }
 
     BundleLink last() {

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/ConfigurableBaseUrlPageLinksTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/ConfigurableBaseUrlPageLinksTest.java
@@ -84,6 +84,12 @@ public class ConfigurableBaseUrlPageLinksTest {
   }
 
   @Test
+  public void onlySelfLinkWhenCountIsZero() {
+    List<BundleLink> actual = links.create(forCurrentPage(2, 0, 15));
+    assertThat(actual).containsExactlyInAnyOrder(link(LinkRelation.self, 2, 0));
+  }
+
+  @Test
   public void previousLinkOmittedWhenOnFirstPage() {
     List<BundleLink> actual = links.create(forCurrentPage(1, 3, 15));
     assertThat(actual)


### PR DESCRIPTION
See https://www.hl7.org/fhir/search.html#count

> if _count has the value 0, this shall be treated the same as _summary=count: the server returns a bundle that reports the total number of resources that match in Bundle.total, but with no entries, and no prev/next/last links.

Links look like this now
```
$ curl -HDatamart:true -sH"$A" "http://localhost:8090/DiagnosticReport?patient=111222333V000999&_count=0" | jq .
{
  "resourceType": "Bundle",
  "type": "searchset",
  "total": 63,
  "link": [
    {
      "relation": "self",
      "url": "http://localhost:8090/api/DiagnosticReport?patient=111222333V000999&page=1&_count=0"
    }
  ],
  "entry": []
}
```