### PR TITLE
Added natural ordering to entities and sorting to AI, Cond, Imm, MedSt and Proc

### DIFF
--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/AllergyIntoleranceController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/AllergyIntoleranceController.java
@@ -253,6 +253,11 @@ public class AllergyIntoleranceController {
       return BooleanUtils.isTrue(BooleanUtils.toBooleanObject(datamartHeader));
     }
 
+    private PageRequest page(int page, int count) {
+      return PageRequest.of(
+          page - 1, count == 0 ? 1 : count, AllergyIntoleranceEntity.naturalOrder());
+    }
+
     AllergyIntolerance read(String publicId) {
       DatamartAllergyIntolerance dm = findById(publicId).asDatamartAllergyIntolerance();
       replaceReferences(List.of(dm));
@@ -277,8 +282,7 @@ public class AllergyIntoleranceController {
       String cdwIcn = witnessProtection.toCdwId(publicIcn);
       int page = Parameters.pageOf(publicParameters);
       int count = Parameters.countOf(publicParameters);
-      Page<AllergyIntoleranceEntity> entitiesPage =
-          repository.findByIcn(cdwIcn, PageRequest.of(page - 1, count == 0 ? 1 : count));
+      Page<AllergyIntoleranceEntity> entitiesPage = repository.findByIcn(cdwIcn, page(page, count));
       List<DatamartAllergyIntolerance> datamarts =
           entitiesPage
               .stream()
@@ -292,8 +296,7 @@ public class AllergyIntoleranceController {
                   dm ->
                       DatamartAllergyIntoleranceTransformer.builder().datamart(dm).build().toFhir())
               .collect(Collectors.toList());
-      return AllergyIntoleranceController.this.bundle(
-          publicParameters, fhir, (int) entitiesPage.getTotalElements());
+      return bundle(publicParameters, fhir, (int) entitiesPage.getTotalElements());
     }
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/AllergyIntoleranceEntity.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/AllergyIntoleranceEntity.java
@@ -15,6 +15,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
+import org.springframework.data.domain.Sort;
 
 @Data
 @Entity
@@ -27,7 +28,7 @@ public class AllergyIntoleranceEntity {
   @Id
   @Column(name = "CDWId")
   @EqualsAndHashCode.Include
-  private String id;
+  private String cdwId;
 
   @Column(name = "PatientFullICN")
   private String icn;
@@ -36,6 +37,10 @@ public class AllergyIntoleranceEntity {
   @Basic(fetch = FetchType.EAGER)
   @Column(name = "AllergyIntolerance")
   private String payload;
+
+  static Sort naturalOrder() {
+    return Sort.by("cdwId").ascending();
+  }
 
   @SneakyThrows
   DatamartAllergyIntolerance asDatamartAllergyIntolerance() {

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/condition/ConditionController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/condition/ConditionController.java
@@ -302,6 +302,10 @@ public class ConditionController {
       return BooleanUtils.isTrue(BooleanUtils.toBooleanObject(datamartHeader));
     }
 
+    private PageRequest page(int page, int count) {
+      return PageRequest.of(page - 1, count == 0 ? 1 : count, ConditionEntity.naturalOrder());
+    }
+
     Condition read(String publicId) {
       DatamartCondition condition = findById(publicId).asDatamartCondition();
       replaceReferences(List.of(condition));
@@ -345,7 +349,7 @@ public class ConditionController {
               .add("_count", count)
               .build(),
           count,
-          repository.findByIcn(icn, PageRequest.of(page - 1, count == 0 ? 1 : count)));
+          repository.findByIcn(icn, page(page, count)));
     }
 
     Bundle searchByPatientAndCategory(String patient, String category, int page, int count) {
@@ -358,8 +362,7 @@ public class ConditionController {
               .add("_count", count)
               .build(),
           count,
-          repository.findByIcnAndCategory(
-              icn, category, PageRequest.of(page - 1, count == 0 ? 1 : count)));
+          repository.findByIcnAndCategory(icn, category, page(page, count)));
     }
 
     Bundle searchByPatientAndClinicalStatus(
@@ -374,9 +377,7 @@ public class ConditionController {
               .build(),
           count,
           repository.findByIcnAndClinicalStatusIn(
-              icn,
-              Set.of(clinicalStatusCsv.split("\\s*,\\s*")),
-              PageRequest.of(page - 1, count == 0 ? 1 : count)));
+              icn, Set.of(clinicalStatusCsv.split("\\s*,\\s*")), page(page, count)));
     }
 
     Condition transform(DatamartCondition dm) {

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/condition/ConditionEntity.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/condition/ConditionEntity.java
@@ -15,6 +15,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
+import org.springframework.data.domain.Sort;
 
 /**
  * Datamart Condition representing the following table.
@@ -61,6 +62,10 @@ public class ConditionEntity {
   @Basic(fetch = FetchType.EAGER)
   @Lob
   private String payload;
+
+  static Sort naturalOrder() {
+    return Sort.by("cdwId").ascending();
+  }
 
   @SneakyThrows
   DatamartCondition asDatamartCondition() {

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/ImmunizationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/ImmunizationController.java
@@ -255,6 +255,10 @@ public class ImmunizationController {
       return BooleanUtils.isTrue(BooleanUtils.toBooleanObject(datamartHeader));
     }
 
+    private PageRequest page(int page, int count) {
+      return PageRequest.of(page - 1, count == 0 ? 1 : count, ImmunizationEntity.naturalOrder());
+    }
+
     Immunization read(String publicId) {
       DatamartImmunization immunization = findById(publicId).asDatamartImmunization();
       replaceReferences(List.of(immunization));
@@ -306,7 +310,7 @@ public class ImmunizationController {
               .add("_count", count)
               .build(),
           count,
-          repository.findByIcn(icn, PageRequest.of(page - 1, count == 0 ? 1 : count)));
+          repository.findByIcn(icn, page(page, count)));
     }
 
     Immunization transform(DatamartImmunization dm) {

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/ImmunizationEntity.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/ImmunizationEntity.java
@@ -15,24 +15,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
+import org.springframework.data.domain.Sort;
 
-/**
- *
- *
- * <pre>
- *  CREATE TABLE [app].[Immunization](
- *         [CDWId] [bigint] NOT NULL,
- *         [PatientFullICN] [varchar](50) NOT NULL,
- *         [PerformerCDWId] [int] NULL,
- *         [RequesterCDWId] [int] NULL,
- *         [DateRecorded] [datetime2](0) NULL,
- *         [Immunization] [varchar](max) NULL,
- *         [ETLBatchId] [int] NULL,
- *         [ETLCreateDate] [datetime2](0) NULL,
- *         [ETLEditDate] [datetime2](0) NULL,
- * PRIMARY KEY CLUSTERED
- * </pre>
- */
 @Data
 @Entity
 @Builder
@@ -53,6 +37,10 @@ public class ImmunizationEntity {
   @Basic(fetch = FetchType.EAGER)
   @Lob
   private String payload;
+
+  static Sort naturalOrder() {
+    return Sort.by("cdwId").ascending();
+  }
 
   @SneakyThrows
   DatamartImmunization asDatamartImmunization() {

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationstatement/MedicationStatementController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationstatement/MedicationStatementController.java
@@ -265,6 +265,11 @@ public class MedicationStatementController {
       return BooleanUtils.isTrue(BooleanUtils.toBooleanObject(datamartHeader));
     }
 
+    private PageRequest page(int page, int count) {
+      return PageRequest.of(
+          page - 1, count == 0 ? 1 : count, MedicationStatementEntity.naturalOrder());
+    }
+
     MedicationStatement read(String publicId) {
       DatamartMedicationStatement medicationStatement =
           findById(publicId).asDatamartMedicationStatement();
@@ -305,7 +310,7 @@ public class MedicationStatementController {
               .add("_count", count)
               .build(),
           count,
-          repository.findByIcn(icn, PageRequest.of(page - 1, count == 0 ? 1 : count)));
+          repository.findByIcn(icn, page(page, count)));
     }
 
     MedicationStatement transform(DatamartMedicationStatement dm) {

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationstatement/MedicationStatementEntity.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationstatement/MedicationStatementEntity.java
@@ -15,6 +15,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
+import org.springframework.data.domain.Sort;
 
 /**
  * Datamart MedicationStatement representing the following table.
@@ -50,6 +51,10 @@ public class MedicationStatementEntity {
   @Basic(fetch = FetchType.EAGER)
   @Lob
   private String payload;
+
+  static Sort naturalOrder() {
+    return Sort.by("cdwId").ascending();
+  }
 
   @SneakyThrows
   DatamartMedicationStatement asDatamartMedicationStatement() {

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/procedure/ProcedureController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/procedure/ProcedureController.java
@@ -349,6 +349,10 @@ public class ProcedureController {
       return BooleanUtils.isTrue(BooleanUtils.toBooleanObject(datamartHeader));
     }
 
+    private PageRequest page(int page, int count) {
+      return PageRequest.of(page - 1, count == 0 ? 1 : count, ProcedureEntity.naturalOrder());
+    }
+
     Procedure read(String publicId, String icnHeader) {
       DatamartProcedure procedure = findById(publicId).asDatamartProcedure();
       replaceReferences(List.of(procedure));
@@ -398,8 +402,7 @@ public class ProcedureController {
       PatientAndDateSpecification spec =
           PatientAndDateSpecification.builder().patient(patient).dates(date).build();
       log.info("Looking for {} ({}) {}", patient, icn, spec);
-      Page<ProcedureEntity> pageOfProcedures =
-          repository.findAll(spec, PageRequest.of(page - 1, count == 0 ? 1 : count));
+      Page<ProcedureEntity> pageOfProcedures = repository.findAll(spec, page(page, count));
 
       Bundle bundle =
           bundle(

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/procedure/ProcedureEntity.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/procedure/ProcedureEntity.java
@@ -15,6 +15,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
+import org.springframework.data.domain.Sort;
 
 @Data
 @Entity
@@ -39,6 +40,10 @@ public class ProcedureEntity {
   @Basic(fetch = FetchType.EAGER)
   @Lob
   private String payload;
+
+  static Sort naturalOrder() {
+    return Sort.by("cdwId").ascending();
+  }
 
   @SneakyThrows
   DatamartProcedure asDatamartProcedure() {

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/DatamartAllergyIntoleranceControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/DatamartAllergyIntoleranceControllerTest.java
@@ -43,7 +43,7 @@ public class DatamartAllergyIntoleranceControllerTest {
   @SneakyThrows
   private AllergyIntoleranceEntity asEntity(DatamartAllergyIntolerance dm) {
     return AllergyIntoleranceEntity.builder()
-        .id(dm.cdwId())
+        .cdwId(dm.cdwId())
         .icn(dm.patient().get().reference().get())
         .payload(JacksonConfig.createMapper().writeValueAsString(dm))
         .build();


### PR DESCRIPTION
This is solving the issue where the same request can have slightly different results:
```
$ curl -sH"$A" -HDatamart:true "https://api.va.gov/services/fhir/v0/dstu2/Immunization?patient=1011537977V693883" | jq -r '.entry[].fullUrl'
https://api.va.gov/services/fhir/v0/dstu2/Immunization/00f4000a-b1c9-5190-993a-644569d2722b
https://api.va.gov/services/fhir/v0/dstu2/Immunization/af5b4cbc-8bc0-59c8-b027-baa78f5c7f59
https://api.va.gov/services/fhir/v0/dstu2/Immunization/1b476df4-429f-53a8-94ec-7521cc3579a9
https://api.va.gov/services/fhir/v0/dstu2/Immunization/a1c8f77b-35f5-53d5-9004-f30425cf8117
https://api.va.gov/services/fhir/v0/dstu2/Immunization/2d65782a-171b-56ed-b265-9a4bcd4c1b98
https://api.va.gov/services/fhir/v0/dstu2/Immunization/3c009e39-7960-56d6-8597-fb1f9d169360
$ curl -sH"$A" -HDatamart:true "https://api.va.gov/services/fhir/v0/dstu2/Immunization?patient=1011537977V693883" | jq -r '.entry[].fullUrl'
https://api.va.gov/services/fhir/v0/dstu2/Immunization/3c009e39-7960-56d6-8597-fb1f9d169360
https://api.va.gov/services/fhir/v0/dstu2/Immunization/af5b4cbc-8bc0-59c8-b027-baa78f5c7f59
https://api.va.gov/services/fhir/v0/dstu2/Immunization/1b476df4-429f-53a8-94ec-7521cc3579a9
https://api.va.gov/services/fhir/v0/dstu2/Immunization/a1c8f77b-35f5-53d5-9004-f30425cf8117
https://api.va.gov/services/fhir/v0/dstu2/Immunization/2d65782a-171b-56ed-b265-9a4bcd4c1b98
https://api.va.gov/services/fhir/v0/dstu2/Immunization/00f4000a-b1c9-5190-993a-644569d2722b
```