### PR TITLE
Bug/adq 200 medication order dispense request number of repeats allowed

### DIFF
--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderTransformer.java
@@ -33,8 +33,9 @@ public class DatamartMedicationOrderTransformer {
       return null;
     }
     DatamartMedicationOrder.DispenseRequest dispenseRequest = maybeDispenseRequest.get();
+    Integer numberOfRepeatsAllowed = dispenseRequest.numberOfRepeatsAllowed().orElse(0);
     return MedicationOrder.DispenseRequest.builder()
-        .numberOfRepeatsAllowed(dispenseRequest.numberOfRepeatsAllowed().orElse(null))
+        .numberOfRepeatsAllowed(numberOfRepeatsAllowed < 1 ? null : numberOfRepeatsAllowed)
         .quantity(simpleQuantity(dispenseRequest.quantity(), dispenseRequest.unit()))
         .expectedSupplyDuration(
             duration(

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderSamples.java
@@ -28,7 +28,7 @@ public class DatamartMedicationOrderSamples {
 
     DatamartMedicationOrder.DispenseRequest dispenseRequest() {
       return DatamartMedicationOrder.DispenseRequest.builder()
-          .numberOfRepeatsAllowed(Optional.of(0))
+          .numberOfRepeatsAllowed(Optional.of(1))
           .quantity(Optional.of(42.0))
           .unit(Optional.of("TAB"))
           .expectedSupplyDuration(Optional.of(21))
@@ -132,7 +132,7 @@ public class DatamartMedicationOrderSamples {
 
     MedicationOrder.DispenseRequest dispenseRequest() {
       return MedicationOrder.DispenseRequest.builder()
-          .numberOfRepeatsAllowed(0)
+          .numberOfRepeatsAllowed(1)
           .quantity(SimpleQuantity.builder().value(42.0).unit("TAB").build())
           .expectedSupplyDuration(Duration.builder().value((double) 21).unit("days").build())
           .build();

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderTransformerTest.java
@@ -28,6 +28,11 @@ public class DatamartMedicationOrderTransformerTest {
     assertThat(tx.dispenseRequest(Optional.empty())).isNull();
     assertThat(tx.dispenseRequest(Optional.of(Datamart.create().dispenseRequest())))
         .isEqualTo(Fhir.create().dispenseRequest());
+    assertThat(
+            tx.dispenseRequest(
+                Optional.of(
+                    Datamart.create().dispenseRequest().numberOfRepeatsAllowed(Optional.of(0)))))
+        .isEqualTo(Fhir.create().dispenseRequest().numberOfRepeatsAllowed(null));
   }
 
   @Test
@@ -74,7 +79,7 @@ public class DatamartMedicationOrderTransformerTest {
 
     public DatamartMedicationOrder.DispenseRequest dispenseRequest() {
       return DatamartMedicationOrder.DispenseRequest.builder()
-          .numberOfRepeatsAllowed(Optional.of(0))
+          .numberOfRepeatsAllowed(Optional.of(1))
           .quantity(Optional.of(42.0))
           .unit(Optional.of("TAB"))
           .expectedSupplyDuration(Optional.of(21))
@@ -143,7 +148,7 @@ public class DatamartMedicationOrderTransformerTest {
 
     public MedicationOrder.DispenseRequest dispenseRequest() {
       return MedicationOrder.DispenseRequest.builder()
-          .numberOfRepeatsAllowed(0)
+          .numberOfRepeatsAllowed(1)
           .quantity(SimpleQuantity.builder().value(42.0).unit("TAB").build())
           .expectedSupplyDuration(Duration.builder().value((double) 21).unit("days").build())
           .build();


### PR DESCRIPTION
Addresses
```
ConstraintViolationImpl{interpolatedMessage='must be greater than or equal to 1', propertyPath=dispenseRequest.numberOfRepeatsAllowed, rootBeanClass=class gov.va.api.health.argonaut.api.resources.MedicationOrder, messageTemplate='{javax.validation.constraints.Min.message}'}
```