### PR TITLE
Task/adq 237 ids properties file

### DIFF
--- a/data-query/pom.xml
+++ b/data-query/pom.xml
@@ -240,6 +240,7 @@
                   <arguments>
                     <argument>${resourceType}</argument>
                     <argument>${inputDirectory}</argument>
+                    <argument>${idsConfig}</argument>
                   </arguments>
                 </configuration>
               </execution>

--- a/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/FhirToDatamart.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/FhirToDatamart.java
@@ -16,27 +16,34 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
-import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@AllArgsConstructor
 public class FhirToDatamart {
 
   private String inputDirectory;
 
   private String resourceType;
 
+  private RevealSecretIdentity fauxIds;
+
+  public FhirToDatamart(String inputDirectory, String resourceType, String idsFile) {
+    this.inputDirectory = inputDirectory;
+    this.resourceType = resourceType;
+    this.fauxIds = new RevealSecretIdentity(idsFile);
+  }
+
   @SneakyThrows
   public static void main(String[] args) {
-    if (args.length != 2) {
+    if (args.length != 3) {
       throw new RuntimeException(
-          "Missing command line arguments. Expected <resource-type> <input-directory>");
+          "Missing command line arguments. Expected <resource-type> <input-directory> <config-file>");
     }
     String resourceType = args[0];
     String inputDirectory = args[1];
-    new FhirToDatamart(inputDirectory, resourceType).fhirToDatamart();
+    String configFile = args[2];
+    new FhirToDatamart(inputDirectory, resourceType, configFile).fhirToDatamart();
     System.exit(0);
   }
 
@@ -100,7 +107,7 @@ public class FhirToDatamart {
     switch (resource) {
       case "AllergyIntolerance":
         F2DAllergyIntoleranceTransformer allergyIntoleranceTransformer =
-            new F2DAllergyIntoleranceTransformer();
+            new F2DAllergyIntoleranceTransformer(fauxIds);
         DatamartAllergyIntolerance datamartAllergyIntolerance =
             allergyIntoleranceTransformer.fhirToDatamart(
                 mapper.readValue(file, AllergyIntolerance.class));
@@ -108,14 +115,14 @@ public class FhirToDatamart {
         break;
       case "DiagnosticReport":
         F2DDiagnosticReportTransformer diagnosticReportTransformer =
-            new F2DDiagnosticReportTransformer();
+            new F2DDiagnosticReportTransformer(fauxIds);
         DatamartDiagnosticReports datamartDiagnosticReports =
             diagnosticReportTransformer.fhirToDatamart(
                 mapper.readValue(file, DiagnosticReport.class));
         dmObjectToFile(file.getName(), datamartDiagnosticReports);
         break;
       case "Patient":
-        F2DPatientTransformer patientTransformer = new F2DPatientTransformer();
+        F2DPatientTransformer patientTransformer = new F2DPatientTransformer(fauxIds);
         DatamartPatient datamartPatient =
             patientTransformer.fhirToDatamart(mapper.readValue(file, Patient.class));
         dmObjectToFile(file.getName(), datamartPatient);

--- a/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/MitreMinimartMaker.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/MitreMinimartMaker.java
@@ -56,6 +56,10 @@ public class MitreMinimartMaker {
 
   /** Main. */
   public static void main(String[] args) {
+    if (args.length != 3) {
+      throw new RuntimeException(
+              "Missing command line arguments. Expected <resource-type> <input-directory> <local-db-location>");
+    }
     String directory = args[1];
     MitreMinimartMaker mmm = new MitreMinimartMaker(args[0], args[2]);
     log.info("Syncing {} files in {} to db", mmm.resourceToSync, directory);

--- a/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/RevealSecretIdentity.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/RevealSecretIdentity.java
@@ -41,8 +41,8 @@ public class RevealSecretIdentity {
 
   public String unmask(String resourceName, String publicId) {
     String idsPropertyName = resourceName.toUpperCase() + "+" + publicId;
-    String cdwId = props.getProperty(idsPropertyName);
-    if (cdwId == null) {
+    String cdwId = props.getProperty(idsPropertyName, "");
+    if (cdwId.isBlank()) {
       throw new RuntimeException("Ids value not found for property: " + idsPropertyName);
     }
     return cdwId;

--- a/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/RevealSecretIdentity.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/RevealSecretIdentity.java
@@ -1,29 +1,36 @@
 package gov.va.api.health.dataquery.tools.minimart;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import gov.va.api.health.autoconfig.configuration.JacksonConfig;
 import gov.va.api.health.dataquery.service.controller.datamart.DatamartReference;
 import gov.va.api.health.dstu2.api.elements.Reference;
-import gov.va.api.health.ids.api.ResourceIdentity;
-import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
-import io.restassured.response.Response;
-import java.util.List;
+import java.io.FileInputStream;
 import java.util.Optional;
+import java.util.Properties;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class RevealSecretIdentity {
 
-  public static Optional<DatamartReference> toDatamartReferenceWithCdwId(Reference reference) {
+  private final Properties props;
+
+  @SneakyThrows
+  RevealSecretIdentity(String configFile) {
+    this.props = new Properties(System.getProperties());
+    try (FileInputStream inputStream = new FileInputStream(configFile)) {
+      props.load(inputStream);
+    }
+  }
+
+  public Optional<DatamartReference> toDatamartReferenceWithCdwId(Reference reference) {
     if (reference == null) {
       return null;
     }
     String[] fhirUrl = reference.reference().split("/");
+    // Fhir Resource
     String referenceType = fhirUrl[fhirUrl.length - 2];
+    // Public Id
     String referenceId = fhirUrl[fhirUrl.length - 1];
-    String realId = unmask(referenceId);
+    String realId = unmask(referenceType, referenceId);
     return Optional.of(
         DatamartReference.builder()
             .type(Optional.of(referenceType))
@@ -32,30 +39,12 @@ public class RevealSecretIdentity {
             .build());
   }
 
-  @SneakyThrows
-  public static String unmask(String villainId) {
-    Response response =
-        RestAssured.given()
-            .headers("Content-Type", ContentType.JSON, "Accept", ContentType.JSON)
-            .when()
-            .get("http://localhost:8089/api/resourceIdentity/{id}", villainId)
-            .then()
-            .contentType(ContentType.JSON)
-            .statusCode(200)
-            .extract()
-            .response();
-
-    String jsonBody = response.getBody().print();
-
-    List<ResourceIdentity> resourceIdentities =
-        JacksonConfig.createMapper()
-            .readValue(jsonBody, new TypeReference<List<ResourceIdentity>>() {});
-
-    return resourceIdentities
-        .stream()
-        .filter(i -> i.system().equalsIgnoreCase("CDW"))
-        .map(ResourceIdentity::identifier)
-        .findFirst()
-        .orElse(null);
+  public String unmask(String resourceName, String publicId) {
+    String idsPropertyName = resourceName.toUpperCase() + "+" + publicId;
+    String cdwId = props.getProperty(idsPropertyName);
+    if (cdwId == null) {
+      throw new RuntimeException("Ids value not found for property: " + idsPropertyName);
+    }
+    return cdwId;
   }
 }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DAllergyIntoleranceTransformer.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DAllergyIntoleranceTransformer.java
@@ -1,12 +1,10 @@
 package gov.va.api.health.dataquery.tools.minimart.transformers;
 
-import static gov.va.api.health.dataquery.tools.minimart.RevealSecretIdentity.toDatamartReferenceWithCdwId;
-import static gov.va.api.health.dataquery.tools.minimart.RevealSecretIdentity.unmask;
-
 import gov.va.api.health.argonaut.api.resources.AllergyIntolerance;
 import gov.va.api.health.dataquery.service.controller.EnumSearcher;
 import gov.va.api.health.dataquery.service.controller.allergyintolerance.DatamartAllergyIntolerance;
 import gov.va.api.health.dataquery.service.controller.datamart.DatamartCoding;
+import gov.va.api.health.dataquery.tools.minimart.RevealSecretIdentity;
 import gov.va.api.health.dstu2.api.datatypes.Annotation;
 import gov.va.api.health.dstu2.api.datatypes.CodeableConcept;
 import gov.va.api.health.dstu2.api.datatypes.Coding;
@@ -14,8 +12,12 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
 
+@AllArgsConstructor
 public class F2DAllergyIntoleranceTransformer {
+
+  RevealSecretIdentity fauxIds;
 
   private DatamartAllergyIntolerance.Category category(AllergyIntolerance.Category category) {
     if (category == null) {
@@ -66,10 +68,10 @@ public class F2DAllergyIntoleranceTransformer {
   public DatamartAllergyIntolerance fhirToDatamart(AllergyIntolerance allergyIntolerance) {
     return DatamartAllergyIntolerance.builder()
         .objectType(allergyIntolerance.resourceType())
-        .cdwId(unmask(allergyIntolerance.id()))
-        .patient(toDatamartReferenceWithCdwId(allergyIntolerance.patient()).get())
+        .cdwId(fauxIds.unmask("AllergyIntolerance", allergyIntolerance.id()))
+        .patient(fauxIds.toDatamartReferenceWithCdwId(allergyIntolerance.patient()).get())
         .recordedDate(dateTime(allergyIntolerance.recordedDate()))
-        .recorder(toDatamartReferenceWithCdwId(allergyIntolerance.recorder()))
+        .recorder(fauxIds.toDatamartReferenceWithCdwId(allergyIntolerance.recorder()))
         .substance(substance(allergyIntolerance.substance()))
         .status(status(allergyIntolerance.status()))
         .type(type(allergyIntolerance.type()))
@@ -90,7 +92,7 @@ public class F2DAllergyIntoleranceTransformer {
   private List<DatamartAllergyIntolerance.Note> notes(Annotation note) {
     return List.of(
         DatamartAllergyIntolerance.Note.builder()
-            .practitioner(toDatamartReferenceWithCdwId(note.authorReference()))
+            .practitioner(fauxIds.toDatamartReferenceWithCdwId(note.authorReference()))
             .text(note.text())
             .time(dateTime(note.time()))
             .build());

--- a/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DDiagnosticReportTransformer.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DDiagnosticReportTransformer.java
@@ -5,13 +5,19 @@ import static org.codehaus.groovy.runtime.InvokerHelper.asList;
 import gov.va.api.health.argonaut.api.resources.DiagnosticReport;
 import gov.va.api.health.dataquery.service.controller.Transformers;
 import gov.va.api.health.dataquery.service.controller.diagnosticreport.DatamartDiagnosticReports;
+import gov.va.api.health.dataquery.tools.minimart.RevealSecretIdentity;
 import java.util.List;
+import lombok.AllArgsConstructor;
 
+@AllArgsConstructor
 public class F2DDiagnosticReportTransformer {
+
+  RevealSecretIdentity fauxIds;
 
   public DatamartDiagnosticReports fhirToDatamart(DiagnosticReport diagnosticReport) {
     return DatamartDiagnosticReports.builder()
-        .fullIcn(splitReference(diagnosticReport.subject().reference(), "Patient"))
+        .fullIcn(
+            fauxIds.unmask("Patient", splitReferenceForId(diagnosticReport.subject().reference())))
         .patientName(diagnosticReport.subject().display())
         .reports(reports(diagnosticReport))
         .build();
@@ -22,12 +28,14 @@ public class F2DDiagnosticReportTransformer {
     return Transformers.emptyToNull(
         asList(
             DatamartDiagnosticReports.DiagnosticReport.builder()
-                .identifier(diagnosticReport.id())
+                .identifier(fauxIds.unmask("DiagnosticReport", diagnosticReport.id()))
                 .effectiveDateTime(diagnosticReport.effectiveDateTime())
                 .issuedDateTime(diagnosticReport.issued())
                 .accessionInstitutionSid(
                     diagnosticReport.performer() != null
-                        ? splitReference(diagnosticReport.performer().reference(), "Organization")
+                        ? fauxIds.unmask(
+                            splitReferenceForType(diagnosticReport.performer().reference()),
+                            splitReferenceForId(diagnosticReport.performer().reference()))
                         : null)
                 .accessionInstitutionName(
                     diagnosticReport.performer() != null
@@ -36,8 +44,13 @@ public class F2DDiagnosticReportTransformer {
                 .build()));
   }
 
-  public String splitReference(String reference, String resource) {
+  private String splitReferenceForId(String reference) {
     String[] splitRef = reference.split("/");
     return splitRef[splitRef.length - 1];
+  }
+
+  private String splitReferenceForType(String reference) {
+    String[] splitRef = reference.split("/");
+    return splitRef[splitRef.length - 2];
   }
 }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DPatientTransformer.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DPatientTransformer.java
@@ -5,6 +5,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import gov.va.api.health.argonaut.api.resources.Patient;
 import gov.va.api.health.dataquery.service.controller.patient.DatamartPatient;
+import gov.va.api.health.dataquery.tools.minimart.RevealSecretIdentity;
 import gov.va.api.health.dstu2.api.datatypes.Address;
 import gov.va.api.health.dstu2.api.datatypes.CodeableConcept;
 import gov.va.api.health.dstu2.api.datatypes.Coding;
@@ -15,8 +16,12 @@ import gov.va.api.health.dstu2.api.elements.Extension;
 import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
 
+@AllArgsConstructor
 public class F2DPatientTransformer {
+
+  RevealSecretIdentity fauxIds;
 
   private DatamartPatient.Address address(Address address) {
     if (address == null) {
@@ -117,7 +122,7 @@ public class F2DPatientTransformer {
     return DatamartPatient.builder()
         .objectVersion(1)
         .objectType(patient.resourceType())
-        .fullIcn(patient.id())
+        .fullIcn(fauxIds.unmask("Patient", patient.id()))
         .firstName(firstName(patient.name()))
         .lastName(lastName(patient.name()))
         .name(name(patient.name()))


### PR DESCRIPTION
[ADQ-237](https://vasdvp.atlassian.net/browse/ADQ-237)

* RevealSecretIdentity.java now uses properties file, not local ids
* Transformers use RSI object to unmask ids
* Shell script passes in properties file location of `health-apis-data-query-synthetic-records/identity-service.properties` (can be overwritten)
