### PR TITLE
fix missing mo fields

### DIFF
--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderTransformer.java
@@ -70,7 +70,7 @@ public class DatamartMedicationOrderTransformer {
   private Duration duration(Optional<Integer> maybeValue) {
     if (maybeValue.isPresent()) {
       return Duration.builder()
-          .value(maybeValue.map(Double::valueOf).orElse(null))
+          .value(Double.valueOf(maybeValue.get()))
           .unit("days")
           .system("http://unitsofmeasure.org")
           .code("d")

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderTransformer.java
@@ -37,9 +37,7 @@ public class DatamartMedicationOrderTransformer {
     return MedicationOrder.DispenseRequest.builder()
         .numberOfRepeatsAllowed(numberOfRepeatsAllowed < 1 ? null : numberOfRepeatsAllowed)
         .quantity(simpleQuantity(dispenseRequest.quantity(), dispenseRequest.unit()))
-        .expectedSupplyDuration(
-            duration(
-                dispenseRequest.expectedSupplyDuration(), dispenseRequest.supplyDurationUnits()))
+        .expectedSupplyDuration(duration(dispenseRequest.expectedSupplyDuration()))
         .build();
   }
 
@@ -69,10 +67,14 @@ public class DatamartMedicationOrderTransformer {
     return results;
   }
 
-  private Duration duration(Optional<Integer> maybeValue, Optional<String> maybeUnit) {
-    if (maybeValue.isPresent() || maybeUnit.isPresent()) {
-      Double durationValue = maybeValue.isPresent() ? Double.valueOf(maybeValue.get()) : null;
-      return Duration.builder().value(durationValue).unit(maybeUnit.orElse(null)).build();
+  private Duration duration(Optional<Integer> maybeValue) {
+    if (maybeValue.isPresent()) {
+      return Duration.builder()
+          .value(maybeValue.map(Double::valueOf).orElse(null))
+          .unit("days")
+          .system("http://unitsofmeasure.org")
+          .code("d")
+          .build();
     }
     return null;
   }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderSamples.java
@@ -134,7 +134,13 @@ public class DatamartMedicationOrderSamples {
       return MedicationOrder.DispenseRequest.builder()
           .numberOfRepeatsAllowed(1)
           .quantity(SimpleQuantity.builder().value(42.0).unit("TAB").build())
-          .expectedSupplyDuration(Duration.builder().value((double) 21).unit("days").build())
+          .expectedSupplyDuration(
+              Duration.builder()
+                  .value((double) 21)
+                  .unit("days")
+                  .code("d")
+                  .system("http://unitsofmeasure.org")
+                  .build())
           .build();
     }
 

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderTransformerTest.java
@@ -150,7 +150,13 @@ public class DatamartMedicationOrderTransformerTest {
       return MedicationOrder.DispenseRequest.builder()
           .numberOfRepeatsAllowed(1)
           .quantity(SimpleQuantity.builder().value(42.0).unit("TAB").build())
-          .expectedSupplyDuration(Duration.builder().value((double) 21).unit("days").build())
+          .expectedSupplyDuration(
+              Duration.builder()
+                  .value((double) 21)
+                  .unit("days")
+                  .code("d")
+                  .system("http://unitsofmeasure.org")
+                  .build())
           .build();
     }
 


### PR DESCRIPTION
New medication orders with system and code:

{
  "resourceType": "MedicationOrder",
  "id": "5d09da19-5f8c-5549-ac70-5c9b865f5d40",
  "dateWritten": "2015-01-15T21:09:41Z",
  "status": "completed",
  "patient": {
    "reference": "http://localhost:8090/api/Patient/111222333V000999",
    "display": "Olson653, Conrad619"
  },
  "_prescriber": {
    "extension": [
      {
        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
        "valueCode": "unsupported"
      }
    ]
  },
  "medicationReference": {
    "reference": "http://localhost:8090/api/Medication/0c65178b-0765-5550-a5fc-11955b6bee24",
    "display": "ALBUTEROL 90MCG (CFC-F) 200D ORAL INHL"
  },
  "dosageInstruction": [
    {
      "text": "USE 2 PUFFS BY MOUTH 4 TIMES PER DAY AS NEEDED FOR BREATHING",
      "timing": {
        "code": {
          "text": "QID PRN"
        }
      },
      "asNeededBoolean": true,
      "route": {
        "text": "INHALATION ORAL"
      }
    }
  ],
  "dispenseRequest": {
    "quantity": {
      "value": 1,
      "unit": "EA"
    },
    "expectedSupplyDuration": {
      "value": 30,
      "unit": "days",
      "system": "http://unitsofmeasure.org",
      "code": "d"
    }
  }
}
