### PR TITLE
Medication.code system will no longer have a trailing slash in http:/…

### DIFF
--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medication/DatamartMedicationTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medication/DatamartMedicationTransformer.java
@@ -22,7 +22,7 @@ public class DatamartMedicationTransformer {
                   Coding.builder()
                       .code(datamart.rxnorm().get().code())
                       .display(datamart.rxnorm().get().text())
-                      .system("https://www.nlm.nih.gov/research/umls/rxnorm/")
+                      .system("https://www.nlm.nih.gov/research/umls/rxnorm")
                       .build()))
           .text(datamart.rxnorm().get().text())
           .build();

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medication/DatamartMedicationSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medication/DatamartMedicationSamples.java
@@ -93,7 +93,7 @@ public class DatamartMedicationSamples {
           .coding(
               List.of(
                   Coding.builder()
-                      .system("https://www.nlm.nih.gov/research/umls/rxnorm/")
+                      .system("https://www.nlm.nih.gov/research/umls/rxnorm")
                       .code("284205")
                       .display("ALMOTRIPTAN MALATE 12.5MG TAB,UD")
                       .build()))


### PR DESCRIPTION
…/www.nlm.nih.gov/research/umls/rxnorm