### PR TITLE
The KBS guidelines are unclear as the coding value of Medication 

### DIFF
--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medication/DatamartMedicationSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medication/DatamartMedicationSamples.java
@@ -84,17 +84,17 @@ public class DatamartMedicationSamples {
           .build();
     }
 
-    CodeableConcept codeLocalDrugName() {
-      return codeLocalDrugName("Axert");
+    CodeableConcept codeLocalDrugNameOnly(String localDrugName) {
+      return CodeableConcept.builder().text(localDrugName).build();
     }
 
-    CodeableConcept codeLocalDrugName(String localDrugName) {
+    CodeableConcept codeLocalDrugNameWithProduct(String localDrugName) {
       return CodeableConcept.builder()
           .text(localDrugName)
           .coding(
               List.of(
                   Coding.builder()
-                      .code("1000")
+                      .code("4015523") // product.id
                       .display(localDrugName)
                       .system("urn:oid:2.16.840.1.113883.6.233")
                       .build()))

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medication/DatamartMedicationTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medication/DatamartMedicationTransformerTest.java
@@ -24,16 +24,23 @@ public class DatamartMedicationTransformerTest {
     dm.rxnorm(rxnorm);
     dm.localDrugName(null);
     assertThat(tx(dm).bestCode()).isEqualTo(DatamartMedicationSamples.Fhir.create().codeRxNorm());
-    // rxnorm: no, localDrugName: yes
+    // rxnorm: no, localDrugName: yes, product: yes
     dm.rxnorm(null);
     dm.localDrugName(localDrugName);
     assertThat(tx(dm).bestCode())
-        .isEqualTo(DatamartMedicationSamples.Fhir.create().codeLocalDrugName());
+        .isEqualTo(
+            DatamartMedicationSamples.Fhir.create().codeLocalDrugNameWithProduct(localDrugName));
+    // rxnorm: no, localDrugName: yes, product: no
+    dm.rxnorm(null);
+    dm.product(Optional.empty());
+    dm.localDrugName(localDrugName);
+    assertThat(tx(dm).bestCode())
+        .isEqualTo(DatamartMedicationSamples.Fhir.create().codeLocalDrugNameOnly(localDrugName));
     // rxnorm: no, localDrugName: no
     dm.rxnorm(null);
     dm.localDrugName(null);
     assertThat(tx(dm).bestCode())
-        .isEqualTo(DatamartMedicationSamples.Fhir.create().codeLocalDrugName("Unknown"));
+        .isEqualTo(DatamartMedicationSamples.Fhir.create().codeLocalDrugNameOnly("Unknown"));
   }
 
   @Test


### PR DESCRIPTION
under certain situations.

This change updates the coding such that

1. If rxnorm information is available, return it as the code.

2. If rxnorm is not available, but product is, then this is a "local" drug. We will use the
local drug name as the text and the code.coding.display value. The product.id is the VA
specific "VUID" medication ID. We want to use this value as the code.coding.code along with the
VA specific system.

3. If neither rxnorm or product is available, we'll create a code with no coding, using just
the local drug name as text.