### PR TITLE
Fhir to datamart: Populate datamart relationship with fhir text field

### DIFF
--- a/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DPatientTransformer.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DPatientTransformer.java
@@ -68,6 +68,7 @@ public class F2DPatientTransformer {
         .phone(phone(contact.telecom()))
         .name(contactName(contact.name()))
         .type(type(contact.relationship()))
+        .relationship(type(contact.relationship()))
         .build();
   }
 


### PR DESCRIPTION
https://vasdvp.atlassian.net/browse/ADQ-278

Story says to map into fhir, but there is no field to represent this data, and we dont care about this field.

Using the fhir text to populate the datamart relationship field since it is non-optional.