### PR TITLE
MedicationOrder.status VistA value support

### DIFF
--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrder.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrder.java
@@ -1,6 +1,5 @@
 package gov.va.api.health.dataquery.service.controller.medicationorder;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import gov.va.api.health.dataquery.service.controller.datamart.DatamartReference;
 import gov.va.api.health.dataquery.service.controller.datamart.HasReplaceableId;
 import java.time.Instant;
@@ -29,7 +28,7 @@ public class DatamartMedicationOrder implements HasReplaceableId {
 
   private Instant dateWritten;
 
-  private Status status;
+  private String status;
 
   private Optional<Instant> dateEnded;
 
@@ -70,15 +69,61 @@ public class DatamartMedicationOrder implements HasReplaceableId {
     /* no op */
   }
 
-  public enum Status {
-    completed,
-    stopped,
-    @JsonProperty(value = "on-hold")
-    on_hold,
-    active,
-    draft,
-    @JsonProperty(value = "entered-in-error")
-    entered_in_error
+  @Data
+  @Builder
+  @AllArgsConstructor(access = AccessLevel.PRIVATE)
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  public static final class DispenseRequest {
+
+    private Optional<Integer> numberOfRepeatsAllowed;
+
+    private Optional<Double> quantity;
+
+    private Optional<String> unit;
+
+    private Optional<Integer> expectedSupplyDuration;
+
+    private Optional<String> supplyDurationUnits;
+
+    /** Lazy initialization with empty. */
+    public Optional<Integer> expectedSupplyDuration() {
+      if (expectedSupplyDuration == null) {
+        return Optional.empty();
+      }
+      return expectedSupplyDuration;
+    }
+
+    /** Lazy initialization with empty. */
+    public Optional<Integer> numberOfRepeatsAllowed() {
+      if (numberOfRepeatsAllowed == null) {
+        return Optional.empty();
+      }
+      return numberOfRepeatsAllowed;
+    }
+
+    /** Lazy initialization with empty. */
+    public Optional<Double> quantity() {
+      if (quantity == null) {
+        return Optional.empty();
+      }
+      return quantity;
+    }
+
+    /** Lazy initialization with empty. */
+    public Optional<String> supplyDurationUnits() {
+      if (supplyDurationUnits == null) {
+        return Optional.empty();
+      }
+      return supplyDurationUnits;
+    }
+
+    /** Lazy initialization with empty. */
+    public Optional<String> unit() {
+      if (unit == null) {
+        return Optional.empty();
+      }
+      return unit;
+    }
   }
 
   @Data
@@ -147,63 +192,6 @@ public class DatamartMedicationOrder implements HasReplaceableId {
         return Optional.empty();
       }
       return timingText;
-    }
-  }
-
-  @Data
-  @Builder
-  @AllArgsConstructor(access = AccessLevel.PRIVATE)
-  @NoArgsConstructor(access = AccessLevel.PRIVATE)
-  public static final class DispenseRequest {
-
-    private Optional<Integer> numberOfRepeatsAllowed;
-
-    private Optional<Double> quantity;
-
-    private Optional<String> unit;
-
-    private Optional<Integer> expectedSupplyDuration;
-
-    private Optional<String> supplyDurationUnits;
-
-    /** Lazy initialization with empty. */
-    public Optional<Integer> expectedSupplyDuration() {
-      if (expectedSupplyDuration == null) {
-        return Optional.empty();
-      }
-      return expectedSupplyDuration;
-    }
-
-    /** Lazy initialization with empty. */
-    public Optional<Integer> numberOfRepeatsAllowed() {
-      if (numberOfRepeatsAllowed == null) {
-        return Optional.empty();
-      }
-      return numberOfRepeatsAllowed;
-    }
-
-    /** Lazy initialization with empty. */
-    public Optional<Double> quantity() {
-      if (quantity == null) {
-        return Optional.empty();
-      }
-      return quantity;
-    }
-
-    /** Lazy initialization with empty. */
-    public Optional<String> supplyDurationUnits() {
-      if (supplyDurationUnits == null) {
-        return Optional.empty();
-      }
-      return supplyDurationUnits;
-    }
-
-    /** Lazy initialization with empty. */
-    public Optional<String> unit() {
-      if (unit == null) {
-        return Optional.empty();
-      }
-      return unit;
     }
   }
 }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderSamples.java
@@ -3,6 +3,7 @@ package gov.va.api.health.dataquery.service.controller.medicationorder;
 import static java.util.Arrays.asList;
 
 import gov.va.api.health.argonaut.api.resources.MedicationOrder;
+import gov.va.api.health.argonaut.api.resources.MedicationOrder.Status;
 import gov.va.api.health.dataquery.service.controller.datamart.DatamartReference;
 import gov.va.api.health.dstu2.api.bundle.AbstractBundle;
 import gov.va.api.health.dstu2.api.bundle.AbstractEntry;
@@ -76,7 +77,7 @@ public class DatamartMedicationOrderSamples {
                   .display("VETERAN,FARM ACY")
                   .build())
           .dateWritten(Instant.parse("2016-11-17T18:02:04Z"))
-          .status(DatamartMedicationOrder.Status.stopped)
+          .status("DISCONTINUED")
           .dateEnded(Optional.of(Instant.parse("2017-02-15T05:00:00Z")))
           .prescriber(
               DatamartReference.of()
@@ -178,7 +179,7 @@ public class DatamartMedicationOrderSamples {
           .patient(
               Reference.builder().reference("Patient/" + icn).display("VETERAN,FARM ACY").build())
           .dateWritten("2016-11-17T18:02:04Z")
-          .status(MedicationOrder.Status.stopped)
+          .status(Status.completed)
           .dateEnded("2017-02-15T05:00:00Z")
           .prescriber(
               Reference.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderTest.java
@@ -12,11 +12,12 @@ import org.junit.Test;
 
 public class DatamartMedicationOrderTest {
 
-  public void assertReadable(String json) throws java.io.IOException {
+  public void assertReadable(String json, DatamartMedicationOrder expected)
+      throws java.io.IOException {
     DatamartMedicationOrder dm =
         createMapper()
             .readValue(getClass().getResourceAsStream(json), DatamartMedicationOrder.class);
-    assertThat(dm).isEqualTo(sample());
+    assertThat(dm).isEqualTo(expected);
   }
 
   public DatamartMedicationOrder sample() {
@@ -29,7 +30,7 @@ public class DatamartMedicationOrderTest {
                 .display("VETERAN,FARM ACY")
                 .build())
         .dateWritten(Instant.parse("2016-11-17T18:02:04Z"))
-        .status(DatamartMedicationOrder.Status.stopped)
+        .status("DISCONTINUED")
         .dateEnded(Optional.of(Instant.parse("2017-02-15T05:00:00Z")))
         .prescriber(
             DatamartReference.of()
@@ -82,12 +83,12 @@ public class DatamartMedicationOrderTest {
   @Test
   @SneakyThrows
   public void unmarshalSample() {
-    assertReadable("datamart-medication-order.json");
+    assertReadable("datamart-medication-order.json", sample());
   }
 
   @Test
   @SneakyThrows
   public void unmarshalSampleV0() {
-    assertReadable("datamart-medication-order-v0.json");
+    assertReadable("datamart-medication-order-v0.json", sample().status("stopped"));
   }
 }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DMedicationOrderTransformer.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DMedicationOrderTransformer.java
@@ -1,12 +1,10 @@
 package gov.va.api.health.dataquery.tools.minimart.transformers;
 
 import gov.va.api.health.argonaut.api.resources.MedicationOrder;
-import gov.va.api.health.dataquery.service.controller.EnumSearcher;
 import gov.va.api.health.dataquery.service.controller.datamart.DatamartReference;
 import gov.va.api.health.dataquery.service.controller.medicationorder.DatamartMedicationOrder;
 import gov.va.api.health.dataquery.service.controller.medicationorder.DatamartMedicationOrder.DispenseRequest;
 import gov.va.api.health.dataquery.service.controller.medicationorder.DatamartMedicationOrder.DosageInstruction;
-import gov.va.api.health.dataquery.service.controller.medicationorder.DatamartMedicationOrder.Status;
 import gov.va.api.health.dataquery.tools.minimart.FhirToDatamartUtils;
 import gov.va.api.health.dstu2.api.datatypes.CodeableConcept;
 import gov.va.api.health.dstu2.api.datatypes.Duration;
@@ -169,11 +167,11 @@ public class F2DMedicationOrderTransformer {
     return route.text();
   }
 
-  private Status status(MedicationOrder.Status status) {
+  private String status(MedicationOrder.Status status) {
     if (status == null) {
       return null;
     }
-    return EnumSearcher.of(DatamartMedicationOrder.Status.class).find(status.toString());
+    return status.toString();
   }
 
   private String timingText(Timing timing) {

--- a/data-query/src/test/resources/gov/va/api/health/dataquery/service/controller/medicationorder/datamart-medication-order.json
+++ b/data-query/src/test/resources/gov/va/api/health/dataquery/service/controller/medicationorder/datamart-medication-order.json
@@ -8,7 +8,7 @@
     "display" : "VETERAN,FARM ACY"
   },
   "dateWritten" : "2016-11-17T18:02:04Z",
-  "status" : "stopped",
+  "status" : "DISCONTINUED",
   "dateEnded" : "2017-02-15T05:00:00Z",
   "prescriber" : {
     "type" : "Practitioner",


### PR DESCRIPTION
MedicationOrder now supports Datamart status values in both the current FHIR-style enumeration values and the future VistA enumeration values. New VistA values are mapped to FHIR values, e.g. DISCONTINUED -> stopped

https://libertyits.slack.com/files/U81B5TXEW/FN8R4B65R/argo1_medicationorderstatusv1.docx