### PR TITLE
Medication Order status field mappings to match the latest KBS guidelines

### DIFF
--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderTransformer.java
@@ -28,33 +28,54 @@ public class DatamartMedicationOrderTransformer {
 
   private static Map<String, Status> STATUS_VALUES =
       ImmutableMap.<String, Status>builder()
-          /* FHIR Values */
-          .put("active", Status.active)
-          .put("on-hold", Status.on_hold)
-          .put("completed", Status.completed)
-          .put("entered-in-error", Status.entered_in_error)
-          .put("stopped", Status.stopped)
-          .put("draft", Status.draft)
-          /* VistA Values */
-          .put("ACTIVE", Status.active)
-          .put("CANCELLED", Status.stopped)
-          .put("COMPLETE", Status.completed)
-          .put("DELAYED", Status.on_hold)
-          .put("DELETED", Status.entered_in_error)
-          .put("DISCONTINUED (EDIT)", Status.stopped)
-          .put("DISCONTINUED BY PROVIDER", Status.stopped)
-          .put("DISCONTINUED", Status.completed)
-          .put("DISCONTINUED/EDIT", Status.stopped)
-          .put("DRUG INTERACTIONS", Status.stopped)
-          .put("EXPIRED", Status.completed)
-          .put("HOLD", Status.on_hold)
-          .put("LAPSED", Status.on_hold)
-          .put("NON-VERIFIED", Status.draft)
-          .put("PENDING", Status.draft)
-          .put("PROVIDER HOLD", Status.on_hold)
-          .put("RENEWED", Status.active)
-          .put("SUSPENDED", Status.on_hold)
-          .put("UNRELEASED", Status.draft)
+          /*
+           * Values per KBS document VADP_Aggregate_190924.xls (2019 Sept 24)
+           */
+          // .put("DISCONTINUED (RENEWAL)",null) // Explicitly marked as <not-used> by KBS
+          // .put("DONE",null) // Explicitly marked as <not-used> by KBS
+          // .put("REFILL",null) // Explicitly marked as <not-used> by KBS
+          // .put("REINSTATED",null) // Explicitly marked as <not-used> by KBS
+          // .put("purge",null) // Explicitly marked as <not-used> by KBS
+          .put("ACTIVE", MedicationOrder.Status.active)
+          .put("DELETED", MedicationOrder.Status.entered_in_error)
+          .put("DISCONTINUED (EDIT)", MedicationOrder.Status.stopped)
+          .put("DISCONTINUED BY PROVIDER", MedicationOrder.Status.stopped)
+          .put("DISCONTINUED", MedicationOrder.Status.stopped)
+          .put("DRUG INTERACTIONS", MedicationOrder.Status.draft)
+          .put("EXPIRED", MedicationOrder.Status.completed)
+          .put("HOLD", MedicationOrder.Status.on_hold)
+          .put("INCOMPLETE", MedicationOrder.Status.draft)
+          .put("NEW ORDER", MedicationOrder.Status.draft)
+          .put("NON-VERIFIED", MedicationOrder.Status.draft)
+          .put("PENDING", MedicationOrder.Status.draft)
+          .put("PROVIDER HOLD", MedicationOrder.Status.on_hold)
+          .put("REFILL REQUEST", MedicationOrder.Status.active)
+          .put("RENEW", MedicationOrder.Status.active)
+          .put("RENEWED", MedicationOrder.Status.active)
+          .put("SUSPENDED", MedicationOrder.Status.on_hold)
+          .put("UNRELEASED", MedicationOrder.Status.draft)
+          .put("active", MedicationOrder.Status.active)
+          .put("discontinued", MedicationOrder.Status.stopped)
+          .put("expired", MedicationOrder.Status.completed)
+          .put("hold", MedicationOrder.Status.on_hold)
+          .put("nonverified", MedicationOrder.Status.draft)
+          .put("on call", MedicationOrder.Status.active)
+          .put("renewed", MedicationOrder.Status.active)
+          /*
+           * Values provided by James Harris based on CDW queries not in the list provided by KBS
+           */
+          .put("CANCELLED", MedicationOrder.Status.stopped)
+          .put("COMPLETE", MedicationOrder.Status.completed)
+          .put("DELAYED", MedicationOrder.Status.on_hold)
+          .put("DISCONTINUED/EDIT", MedicationOrder.Status.stopped)
+          .put("LAPSED", MedicationOrder.Status.on_hold)
+          /* FHIR values */
+          // .put("active", MedicationOrder.Status.active) // Duplicated in KBS
+          .put("completed", MedicationOrder.Status.completed)
+          .put("draft", MedicationOrder.Status.draft)
+          .put("entered-in-error", MedicationOrder.Status.entered_in_error)
+          .put("on-hold", MedicationOrder.Status.on_hold)
+          .put("stopped", MedicationOrder.Status.stopped)
           .build();
 
   @NonNull private final DatamartMedicationOrder datamart;

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderSamples.java
@@ -179,7 +179,7 @@ public class DatamartMedicationOrderSamples {
           .patient(
               Reference.builder().reference("Patient/" + icn).display("VETERAN,FARM ACY").build())
           .dateWritten("2016-11-17T18:02:04Z")
-          .status(Status.completed)
+          .status(Status.stopped)
           .dateEnded("2017-02-15T05:00:00Z")
           .prescriber(
               Reference.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/DatamartMedicationOrderTransformerTest.java
@@ -78,34 +78,60 @@ public class DatamartMedicationOrderTransformerTest {
     assertThat(tx.status("")).isNull();
     /* VistA values */
     assertThat(tx.status("*Unknown at this time*")).isNull();
-    assertThat(tx.status("NULL")).isNull();
     assertThat(tx.status("*Missing*")).isNull();
     assertThat(tx.status("1234")).isNull();
+    assertThat(tx.status("NULL")).isNull();
+
+    /*
+     * Values per KBS document VADP_Aggregate_190924.xls (2019 Sept 24)
+     */
     assertThat(tx.status("ACTIVE")).isEqualTo(MedicationOrder.Status.active);
-    assertThat(tx.status("CANCELLED")).isEqualTo(MedicationOrder.Status.stopped);
-    assertThat(tx.status("COMPLETE")).isEqualTo(MedicationOrder.Status.completed);
-    assertThat(tx.status("DELAYED")).isEqualTo(MedicationOrder.Status.on_hold);
     assertThat(tx.status("DELETED")).isEqualTo(MedicationOrder.Status.entered_in_error);
     assertThat(tx.status("DISCONTINUED (EDIT)")).isEqualTo(MedicationOrder.Status.stopped);
+    assertThat(tx.status("DISCONTINUED (RENEWAL)")).isNull();
     assertThat(tx.status("DISCONTINUED BY PROVIDER")).isEqualTo(MedicationOrder.Status.stopped);
-    assertThat(tx.status("DISCONTINUED")).isEqualTo(MedicationOrder.Status.completed);
-    assertThat(tx.status("DISCONTINUED/EDIT")).isEqualTo(MedicationOrder.Status.stopped);
-    assertThat(tx.status("DRUG INTERACTIONS")).isEqualTo(MedicationOrder.Status.stopped);
+    assertThat(tx.status("DISCONTINUED")).isEqualTo(MedicationOrder.Status.stopped);
+    assertThat(tx.status("DONE")).isNull();
+    assertThat(tx.status("DRUG INTERACTIONS")).isEqualTo(MedicationOrder.Status.draft);
     assertThat(tx.status("EXPIRED")).isEqualTo(MedicationOrder.Status.completed);
     assertThat(tx.status("HOLD")).isEqualTo(MedicationOrder.Status.on_hold);
-    assertThat(tx.status("LAPSED")).isEqualTo(MedicationOrder.Status.on_hold);
+    assertThat(tx.status("INCOMPLETE")).isEqualTo(MedicationOrder.Status.draft);
+    assertThat(tx.status("NEW ORDER")).isEqualTo(MedicationOrder.Status.draft);
     assertThat(tx.status("NON-VERIFIED")).isEqualTo(MedicationOrder.Status.draft);
     assertThat(tx.status("PENDING")).isEqualTo(MedicationOrder.Status.draft);
     assertThat(tx.status("PROVIDER HOLD")).isEqualTo(MedicationOrder.Status.on_hold);
+    assertThat(tx.status("REFILL REQUEST")).isEqualTo(MedicationOrder.Status.active);
+    assertThat(tx.status("REFILL")).isNull();
+    assertThat(tx.status("REINSTATED")).isNull();
+    assertThat(tx.status("RENEW")).isEqualTo(MedicationOrder.Status.active);
     assertThat(tx.status("RENEWED")).isEqualTo(MedicationOrder.Status.active);
     assertThat(tx.status("SUSPENDED")).isEqualTo(MedicationOrder.Status.on_hold);
     assertThat(tx.status("UNRELEASED")).isEqualTo(MedicationOrder.Status.draft);
+    assertThat(tx.status("active")).isEqualTo(MedicationOrder.Status.active);
+    assertThat(tx.status("discontinued")).isEqualTo(MedicationOrder.Status.stopped);
+    assertThat(tx.status("expired")).isEqualTo(MedicationOrder.Status.completed);
+    assertThat(tx.status("hold")).isEqualTo(MedicationOrder.Status.on_hold);
+    assertThat(tx.status("nonverified")).isEqualTo(MedicationOrder.Status.draft);
+    assertThat(tx.status("on call")).isEqualTo(MedicationOrder.Status.active);
+    assertThat(tx.status("purge")).isNull();
+    assertThat(tx.status("renewed")).isEqualTo(MedicationOrder.Status.active);
+    /*
+     * Values provided by James Harris based on CDW queries not in the list provided by KBS
+     */
+    assertThat(tx.status("CANCELLED")).isEqualTo(MedicationOrder.Status.stopped);
+    assertThat(tx.status("COMPLETE")).isEqualTo(MedicationOrder.Status.completed);
+    assertThat(tx.status("DELAYED")).isEqualTo(MedicationOrder.Status.on_hold);
+    assertThat(tx.status("DISCONTINUED/EDIT")).isEqualTo(MedicationOrder.Status.stopped);
+    assertThat(tx.status("LAPSED")).isEqualTo(MedicationOrder.Status.on_hold);
+    assertThat(tx.status("NON-VERIFIED")).isEqualTo(MedicationOrder.Status.draft);
+
     /* FHIR values */
     assertThat(tx.status("active")).isEqualTo(MedicationOrder.Status.active);
     assertThat(tx.status("completed")).isEqualTo(MedicationOrder.Status.completed);
     assertThat(tx.status("draft")).isEqualTo(MedicationOrder.Status.draft);
     assertThat(tx.status("entered-in-error")).isEqualTo(MedicationOrder.Status.entered_in_error);
     assertThat(tx.status("on-hold")).isEqualTo(MedicationOrder.Status.on_hold);
+    assertThat(tx.status("stopped")).isEqualTo(MedicationOrder.Status.stopped);
   }
 
   MedicationOrder tx(DatamartMedicationOrder datamart) {


### PR DESCRIPTION
Conversation:
https://libertyits.slack.com/archives/GNKFNQ5FE/p1569351705061200

Snippet from KBS mapping guidelines
```
'DC' FOR DISCONTINUED;    stopped
'DE' FOR DISCONTINUED (EDIT);    stopped
'HD' FOR HOLD;    on-hold
'RNW' FOR RENEW;    active
'RF' FOR REFILL REQUEST;    active
'NW' FOR NEW ORDER;    draft
0' FOR ACTIVE;     active
12' FOR DISCONTINUED;      stopped
'1' FOR NON-VERIFIED;    draft
'15' FOR DISCONTINUED (EDIT);    stopped
11' FOR EXPIRED;     completed
3' FOR HOLD;     on-hold
'10' FOR DONE;    <not used>
'2' FOR REFILL;    <not used>
'4' FOR DRUG INTERACTIONS;    draft
5' FOR SUSPENDED;     on-hold
'13' FOR DELETED;    entered-in-error
'14' FOR DISCONTINUED BY PROVIDER;    stopped
'16' FOR PROVIDER HOLD;    on-hold
A' FOR ACTIVE    active
D' FOR DISCONTINUED    stopped
I' FOR INCOMPLETE    draft
N' FOR NON-VERIFIED    draft
U' FOR UNRELEASED    draft
P' FOR PENDING    draft
DE' FOR DISCONTINUED (EDIT)    stopped
A for active    active
D for discontinued    stopped
N for nonverified    draft
E for expired    completed
H for hold    on-hold
R for renewed    active
O for on call    active
P for purge    <not used>
'A' FOR ACTIVE;    active
'D' FOR DISCONTINUED;    stopped
'DE' FOR DISCONTINUED (EDIT);    stopped
'E' FOR EXPIRED;    completed
'H' FOR HOLD;    on-hold
'R' FOR RENEWED;    active
'RE' FOR REINSTATED;    <not used>
'DR' FOR DISCONTINUED (RENEWAL);"    <not used>
```