### PR TITLE
SHANK-139 Performance Tuning for bulk Patient endpoint

### DIFF
--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/PatientBulkFhirIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/PatientBulkFhirIT.java
@@ -9,6 +9,9 @@ import gov.va.api.health.dataquery.tests.categories.LabDataQueryPatient;
 import gov.va.api.health.dataquery.tests.categories.ProdDataQueryPatient;
 import gov.va.api.health.sentinel.ExpectedResponse;
 import gov.va.api.health.sentinel.categories.Local;
+import gov.va.api.health.sentinel.categories.Manual;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.LinkedList;
 import java.util.List;
 import lombok.SneakyThrows;
@@ -60,6 +63,30 @@ public class PatientBulkFhirIT {
     assertThat(allPatients)
         .withFailMessage("We can't look at production data on failures.")
         .isEqualTo(combined);
+  }
+
+  @Test
+  @Category(Manual.class)
+  public void bulkFhirPatientSearchPerformance() {
+    /*
+     * We will ask for 5000 patients 100 times and log out the time it took to complete
+     */
+    log.info("Get a large chunk of patients 100x: internal/bulk/Patient?page=x&_count=y");
+    Instant start = Instant.now();
+
+    for (int i = 0; i < 100; i++) {
+      ExpectedResponse responseAll =
+          TestClients.internalDataQuery()
+              .get(
+                  ImmutableMap.of("bulk", System.getProperty("bulk-token", "some-token")),
+                  apiPath() + "internal/bulk/Patient?page=1&_count=5000");
+      responseAll.expect(200);
+      responseAll.expectListOf(Patient.class);
+    }
+    Instant complete = Instant.now();
+    log.info(
+        "Call took {} milliseconds to complete retrieving patients 100 times",
+        Duration.between(start, complete).toMillis());
   }
 
   @Test

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/PatientBulkFhirController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/PatientBulkFhirController.java
@@ -59,9 +59,9 @@ public class PatientBulkFhirController {
       @RequestParam(value = "_count", defaultValue = "15") @Min(0) int count) {
     PageAndCountValidator.validateCountBounds(count, maxRecordsPerPage);
     return repository
-        .findAll(page(page, count))
+        .findAllProjectedBy(page(page, count))
         .stream()
-        .map(PatientEntity::asDatamartPatient)
+        .map(PatientPayloadDto::asDatamartPatient)
         .map(dm -> DatamartPatientTransformer.builder().datamart(dm).build().toFhir())
         .collect(Collectors.toList());
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/PatientPayloadDto.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/PatientPayloadDto.java
@@ -1,0 +1,19 @@
+package gov.va.api.health.dataquery.service.controller.patient;
+
+import gov.va.api.health.autoconfig.configuration.JacksonConfig;
+import lombok.SneakyThrows;
+import lombok.Value;
+
+/**
+ * A limited view of the Patient object that will just contain the payload data to be transformed to
+ * a DatamartPatient.
+ */
+@Value
+public class PatientPayloadDto {
+  String payload;
+
+  @SneakyThrows
+  DatamartPatient asDatamartPatient() {
+    return JacksonConfig.createMapper().readValue(payload, DatamartPatient.class);
+  }
+}

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/PatientRepository.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/PatientRepository.java
@@ -1,7 +1,17 @@
 package gov.va.api.health.dataquery.service.controller.patient;
 
 import gov.va.api.health.autoconfig.logging.Loggable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 @Loggable
-public interface PatientRepository extends PagingAndSortingRepository<PatientEntity, String> {}
+public interface PatientRepository extends PagingAndSortingRepository<PatientEntity, String> {
+  /**
+   * A paged search that returns a view of the patients with just the payload column read.
+   *
+   * @param page The page data to find
+   * @return A page of patient payloads
+   */
+  Page<PatientPayloadDto> findAllProjectedBy(Pageable page);
+}


### PR DESCRIPTION
* Created PatientPayloadDto for JPA projection
* Updated the PatientRepository to have a method to get the projected data. 
* Added an Integration test to repeatedly ask for data to evaluate performance of the endpoint.
   *  Performance stats running this IT asking for 84 patients 100 times in a row
       * Without this change: Average ~14.5 seconds
       * With this change: Average ~11.5 seconds
       * Thats about a 20% improvement