### PR TITLE
SSS-94 Add dstu2 prefix to utility classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 ### STS ###
 .apt_generated
+.checkstyle
 .classpath
 .factorypath
 .project

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/Dstu2Bundler.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/Dstu2Bundler.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Service;
  */
 @Service
 @RequiredArgsConstructor(onConstructor = @__({@Autowired}))
-public class Bundler {
+public class Dstu2Bundler {
   private final PageLinks links;
 
   /** Return new bundle, filled with entries created by transforming the XML items. */

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/Dstu2Transformers.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/Dstu2Transformers.java
@@ -33,7 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 /** Utility methods for transforming CDW results to Argonaut. */
 @Slf4j
 @UtilityClass
-public final class Transformers {
+public final class Dstu2Transformers {
 
   /**
    * Return false if at least one value in the given list is a non-blank string, or a non-null

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/Dstu2Validator.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/Dstu2Validator.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 
 /** This support utility provides the mechanism need to for Argonaut `$validate` endpoint. */
 @NoArgsConstructor(staticName = "create")
-public class Validator {
+public class Dstu2Validator {
   /**
    * Return a new "all ok" validation response. This is the payload that indicates the validated
    * bundle is valid.

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/WebExceptionHandler.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/WebExceptionHandler.java
@@ -89,7 +89,7 @@ public class WebExceptionHandler {
     return responseFor("structure", e, request);
   }
 
-  @ExceptionHandler({Transformers.MissingPayload.class})
+  @ExceptionHandler({Dstu2Transformers.MissingPayload.class})
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public OperationOutcome handleMissingPayload(Exception e, HttpServletRequest request) {
     request.getParameter("_id");

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/Dstu2AllergyIntoleranceController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/Dstu2AllergyIntoleranceController.java
@@ -5,12 +5,12 @@ import static java.util.Collections.emptyList;
 
 import gov.va.api.health.argonaut.api.resources.AllergyIntolerance;
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
 import gov.va.api.health.dataquery.service.controller.CountParameter;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks;
 import gov.va.api.health.dataquery.service.controller.Parameters;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dstu2.api.resources.OperationOutcome;
 import java.util.Collection;
@@ -48,7 +48,7 @@ import org.springframework.web.bind.annotation.RestController;
 )
 public class Dstu2AllergyIntoleranceController {
 
-  private Bundler bundler;
+  private Dstu2Bundler bundler;
 
   private WitnessProtection witnessProtection;
 
@@ -56,7 +56,7 @@ public class Dstu2AllergyIntoleranceController {
 
   /** Autowired constructor. */
   public Dstu2AllergyIntoleranceController(
-      @Autowired Bundler bundler,
+      @Autowired Dstu2Bundler bundler,
       @Autowired AllergyIntoleranceRepository repository,
       @Autowired WitnessProtection witnessProtection) {
     this.bundler = bundler;
@@ -77,7 +77,7 @@ public class Dstu2AllergyIntoleranceController {
             .totalRecords(totalRecords)
             .build();
     return bundler.bundle(
-        Bundler.BundleContext.of(
+        Dstu2Bundler.BundleContext.of(
             linkConfig,
             records,
             Function.identity(),
@@ -196,6 +196,6 @@ public class Dstu2AllergyIntoleranceController {
     consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
   )
   public OperationOutcome validate(@RequestBody AllergyIntolerance.Bundle bundle) {
-    return Validator.create().validate(bundle);
+    return Dstu2Validator.create().validate(bundle);
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/Dstu2AllergyIntoleranceIncludesIcnMajig.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/Dstu2AllergyIntoleranceIncludesIcnMajig.java
@@ -4,7 +4,7 @@ import gov.va.api.health.argonaut.api.resources.AllergyIntolerance;
 import gov.va.api.health.argonaut.api.resources.AllergyIntolerance.Bundle;
 import gov.va.api.health.argonaut.api.resources.AllergyIntolerance.Entry;
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Transformers;
+import gov.va.api.health.dataquery.service.controller.Dstu2Transformers;
 import java.util.stream.Stream;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 
@@ -22,6 +22,6 @@ public class Dstu2AllergyIntoleranceIncludesIcnMajig
     super(
         AllergyIntolerance.class,
         Bundle.class,
-        (body) -> Stream.ofNullable(Transformers.asReferenceId(body.patient())));
+        (body) -> Stream.ofNullable(Dstu2Transformers.asReferenceId(body.patient())));
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/Dstu2AllergyIntoleranceTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/Dstu2AllergyIntoleranceTransformer.java
@@ -1,10 +1,10 @@
 package gov.va.api.health.dataquery.service.controller.allergyintolerance;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.allBlank;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asCoding;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateTimeString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asReference;
-import static gov.va.api.health.dataquery.service.controller.Transformers.emptyToNull;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.allBlank;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asCoding;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateTimeString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asReference;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.emptyToNull;
 import static java.util.Arrays.asList;
 import static org.springframework.util.CollectionUtils.isEmpty;
 

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/appointment/AppointmentController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/appointment/AppointmentController.java
@@ -1,14 +1,14 @@
 package gov.va.api.health.dataquery.service.controller.appointment;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.firstPayloadItem;
-import static gov.va.api.health.dataquery.service.controller.Transformers.hasPayload;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.firstPayloadItem;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.hasPayload;
 
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
 import gov.va.api.health.dataquery.service.controller.CountParameter;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
 import gov.va.api.health.dataquery.service.mranderson.client.Query.Profile;
@@ -46,7 +46,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AppointmentController {
   private Transformer transformer;
   private MrAndersonClient mrAndersonClient;
-  private Bundler bundler;
+  private Dstu2Bundler bundler;
 
   private Appointment.Bundle bundle(MultiValueMap<String, String> parameters, int page, int count) {
     CdwAppointment101Root root = search(parameters);
@@ -135,7 +135,7 @@ public class AppointmentController {
     consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
   )
   public OperationOutcome validate(@RequestBody Appointment.Bundle bundle) {
-    return Validator.create().validate(bundle);
+    return Dstu2Validator.create().validate(bundle);
   }
 
   public interface Transformer

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/appointment/AppointmentIncludesIcnMajig.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/appointment/AppointmentIncludesIcnMajig.java
@@ -1,7 +1,7 @@
 package gov.va.api.health.dataquery.service.controller.appointment;
 
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Transformers;
+import gov.va.api.health.dataquery.service.controller.Dstu2Transformers;
 import gov.va.api.health.dstu2.api.resources.Appointment;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -28,7 +28,7 @@ public class AppointmentIncludesIcnMajig
                         .stream()
                         .map(p -> p.actor())
                         .filter(r -> r.reference().contains("Patient"))
-                        .map(i -> Transformers.asReferenceId(i))
+                        .map(i -> Dstu2Transformers.asReferenceId(i))
                         .collect(Collectors.joining(","))));
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/appointment/AppointmentTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/appointment/AppointmentTransformer.java
@@ -1,11 +1,11 @@
 package gov.va.api.health.dataquery.service.controller.appointment;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.allBlank;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateTimeString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asInteger;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convert;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convertAll;
-import static gov.va.api.health.dataquery.service.controller.Transformers.ifPresent;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.allBlank;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateTimeString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asInteger;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convert;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convertAll;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.ifPresent;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import gov.va.api.health.dataquery.service.controller.EnumSearcher;

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/condition/ConditionController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/condition/ConditionController.java
@@ -1,20 +1,20 @@
 package gov.va.api.health.dataquery.service.controller.condition;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.firstPayloadItem;
-import static gov.va.api.health.dataquery.service.controller.Transformers.hasPayload;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.firstPayloadItem;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.hasPayload;
 import static java.util.Collections.emptyList;
 
 import gov.va.api.health.argonaut.api.resources.Condition;
 import gov.va.api.health.argonaut.api.resources.Condition.Bundle;
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
 import gov.va.api.health.dataquery.service.controller.CountParameter;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions.NotFound;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
@@ -68,7 +68,7 @@ public class ConditionController {
 
   private MrAndersonClient mrAndersonClient;
 
-  private Bundler bundler;
+  private Dstu2Bundler bundler;
 
   private ConditionRepository repository;
 
@@ -82,7 +82,7 @@ public class ConditionController {
       @Value("${datamart.condition}") boolean defaultToDatamart,
       @Autowired Transformer transformer,
       @Autowired MrAndersonClient mrAndersonClient,
-      @Autowired Bundler bundler,
+      @Autowired Dstu2Bundler bundler,
       @Autowired ConditionRepository repository,
       @Autowired WitnessProtection witnessProtection) {
     this.defaultToDatamart = defaultToDatamart;
@@ -245,7 +245,7 @@ public class ConditionController {
     consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
   )
   public OperationOutcome validate(@RequestBody Condition.Bundle bundle) {
-    return Validator.create().validate(bundle);
+    return Dstu2Validator.create().validate(bundle);
   }
 
   public interface Transformer
@@ -268,7 +268,7 @@ public class ConditionController {
               .totalRecords(totalRecords)
               .build();
       return bundler.bundle(
-          Bundler.BundleContext.of(
+          Dstu2Bundler.BundleContext.of(
               linkConfig,
               reports,
               Function.identity(),

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/condition/ConditionIncludesIcnMajig.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/condition/ConditionIncludesIcnMajig.java
@@ -2,7 +2,7 @@ package gov.va.api.health.dataquery.service.controller.condition;
 
 import gov.va.api.health.argonaut.api.resources.Condition;
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Transformers;
+import gov.va.api.health.dataquery.service.controller.Dstu2Transformers;
 import java.util.stream.Stream;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 
@@ -19,6 +19,6 @@ public class ConditionIncludesIcnMajig
     super(
         Condition.class,
         Condition.Bundle.class,
-        body -> Stream.ofNullable(Transformers.asReferenceId(body.patient())));
+        body -> Stream.ofNullable(Dstu2Transformers.asReferenceId(body.patient())));
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/condition/ConditionTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/condition/ConditionTransformer.java
@@ -1,11 +1,11 @@
 package gov.va.api.health.dataquery.service.controller.condition;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.allBlank;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateTimeString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convert;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convertAll;
-import static gov.va.api.health.dataquery.service.controller.Transformers.ifPresent;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.allBlank;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateTimeString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convert;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convertAll;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.ifPresent;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import gov.va.api.health.argonaut.api.resources.Condition;

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/condition/DatamartConditionTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/condition/DatamartConditionTransformer.java
@@ -1,9 +1,9 @@
 package gov.va.api.health.dataquery.service.controller.condition;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateTimeString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asReference;
-import static gov.va.api.health.dataquery.service.controller.Transformers.ifPresent;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateTimeString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asReference;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.ifPresent;
 
 import gov.va.api.health.argonaut.api.resources.Condition;
 import gov.va.api.health.argonaut.api.resources.Condition.VerificationStatusCode;

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/DatamartDiagnosticReportTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/DatamartDiagnosticReportTransformer.java
@@ -1,14 +1,14 @@
 package gov.va.api.health.dataquery.service.controller.diagnosticreport;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.allBlank;
-import static gov.va.api.health.dataquery.service.controller.Transformers.emptyToNull;
-import static gov.va.api.health.dataquery.service.controller.Transformers.parseInstant;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.allBlank;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.emptyToNull;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.parseInstant;
 import static java.util.Arrays.asList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.springframework.util.CollectionUtils.isEmpty;
 
 import gov.va.api.health.argonaut.api.resources.DiagnosticReport;
-import gov.va.api.health.dataquery.service.controller.Transformers;
+import gov.va.api.health.dataquery.service.controller.Dstu2Transformers;
 import gov.va.api.health.dataquery.service.controller.diagnosticreport.DatamartDiagnosticReports.Result;
 import gov.va.api.health.dstu2.api.DataAbsentReason;
 import gov.va.api.health.dstu2.api.datatypes.CodeableConcept;
@@ -34,7 +34,7 @@ final class DatamartDiagnosticReportTransformer {
     if (r == null) {
       return null;
     }
-    if (Transformers.isBlank(r.display()) || Transformers.isBlank(r.result())) {
+    if (Dstu2Transformers.isBlank(r.display()) || Dstu2Transformers.isBlank(r.result())) {
       return null;
     }
     return Reference.builder().display(r.display()).reference("Observation/" + r.result()).build();

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/DiagnosticReportController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/DiagnosticReportController.java
@@ -1,8 +1,8 @@
 package gov.va.api.health.dataquery.service.controller.diagnosticreport;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.firstPayloadItem;
-import static gov.va.api.health.dataquery.service.controller.Transformers.hasPayload;
-import static gov.va.api.health.dataquery.service.controller.Transformers.parseInstant;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.firstPayloadItem;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.hasPayload;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.parseInstant;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
@@ -15,15 +15,15 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Table;
 import gov.va.api.health.argonaut.api.resources.DiagnosticReport;
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
 import gov.va.api.health.dataquery.service.controller.CountParameter;
 import gov.va.api.health.dataquery.service.controller.DateTimeParameter;
 import gov.va.api.health.dataquery.service.controller.DateTimeParameters;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks;
 import gov.va.api.health.dataquery.service.controller.Parameters;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions.NotFound;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
@@ -82,7 +82,7 @@ public class DiagnosticReportController {
 
   private MrAndersonClient mrAndersonClient;
 
-  private Bundler bundler;
+  private Dstu2Bundler bundler;
 
   private WitnessProtection witnessProtection;
 
@@ -95,7 +95,7 @@ public class DiagnosticReportController {
       @Value("${datamart.diagnostic-report}") boolean defaultToDatamart,
       @Autowired Transformer transformer,
       @Autowired MrAndersonClient mrAndersonClient,
-      @Autowired Bundler bundler,
+      @Autowired Dstu2Bundler bundler,
       @Autowired WitnessProtection witnessProtection,
       @Autowired EntityManager entityManager) {
     this.defaultToDatamart = defaultToDatamart;
@@ -145,7 +145,7 @@ public class DiagnosticReportController {
             .totalRecords(totalRecords)
             .build();
     return bundler.bundle(
-        Bundler.BundleContext.of(
+        Dstu2Bundler.BundleContext.of(
             linkConfig,
             reports,
             Function.identity(),
@@ -279,7 +279,7 @@ public class DiagnosticReportController {
             .totalRecords(root.getRecordCount().intValue())
             .build();
     return bundler.bundle(
-        Bundler.BundleContext.of(
+        Dstu2Bundler.BundleContext.of(
             linkConfig,
             root.getDiagnosticReports() == null
                 ? Collections.emptyList()
@@ -507,7 +507,7 @@ public class DiagnosticReportController {
     consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
   )
   public OperationOutcome validate(@RequestBody DiagnosticReport.Bundle bundle) {
-    return Validator.create().validate(bundle);
+    return Dstu2Validator.create().validate(bundle);
   }
 
   public interface Transformer

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/DiagnosticReportIncludesIcnMajig.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/DiagnosticReportIncludesIcnMajig.java
@@ -2,7 +2,7 @@ package gov.va.api.health.dataquery.service.controller.diagnosticreport;
 
 import gov.va.api.health.argonaut.api.resources.DiagnosticReport;
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Transformers;
+import gov.va.api.health.dataquery.service.controller.Dstu2Transformers;
 import java.util.stream.Stream;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 
@@ -20,6 +20,6 @@ public class DiagnosticReportIncludesIcnMajig
     super(
         DiagnosticReport.class,
         DiagnosticReport.Bundle.class,
-        body -> Stream.ofNullable(Transformers.asReferenceId(body.subject())));
+        body -> Stream.ofNullable(Dstu2Transformers.asReferenceId(body.subject())));
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/DiagnosticReportTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/DiagnosticReportTransformer.java
@@ -1,10 +1,10 @@
 package gov.va.api.health.dataquery.service.controller.diagnosticreport;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.allBlank;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateTimeString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convert;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convertAll;
-import static gov.va.api.health.dataquery.service.controller.Transformers.ifPresent;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.allBlank;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateTimeString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convert;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convertAll;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.ifPresent;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import gov.va.api.health.argonaut.api.resources.DiagnosticReport;

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/encounter/EncounterController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/encounter/EncounterController.java
@@ -1,14 +1,14 @@
 package gov.va.api.health.dataquery.service.controller.encounter;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.firstPayloadItem;
-import static gov.va.api.health.dataquery.service.controller.Transformers.hasPayload;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.firstPayloadItem;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.hasPayload;
 
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
 import gov.va.api.health.dataquery.service.controller.CountParameter;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
 import gov.va.api.health.dstu2.api.resources.Encounter;
@@ -44,7 +44,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class EncounterController {
   private Transformer transformer;
   private MrAndersonClient mrAndersonClient;
-  private Bundler bundler;
+  private Dstu2Bundler bundler;
 
   private Encounter.Bundle bundle(MultiValueMap<String, String> parameters, int page, int count) {
     CdwEncounter101Root root = search(parameters);
@@ -120,7 +120,7 @@ public class EncounterController {
     consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
   )
   public OperationOutcome validate(@RequestBody Encounter.Bundle bundle) {
-    return Validator.create().validate(bundle);
+    return Dstu2Validator.create().validate(bundle);
   }
 
   public interface Transformer

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/encounter/EncounterIncludesIcnMajig.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/encounter/EncounterIncludesIcnMajig.java
@@ -1,7 +1,7 @@
 package gov.va.api.health.dataquery.service.controller.encounter;
 
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Transformers;
+import gov.va.api.health.dataquery.service.controller.Dstu2Transformers;
 import gov.va.api.health.dstu2.api.resources.Encounter;
 import java.util.stream.Stream;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -19,6 +19,6 @@ public class EncounterIncludesIcnMajig
     super(
         Encounter.class,
         Encounter.Bundle.class,
-        body -> Stream.ofNullable(Transformers.asReferenceId(body.patient())));
+        body -> Stream.ofNullable(Dstu2Transformers.asReferenceId(body.patient())));
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/encounter/EncounterTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/encounter/EncounterTransformer.java
@@ -1,10 +1,10 @@
 package gov.va.api.health.dataquery.service.controller.encounter;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.allBlank;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateTimeString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convert;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convertAll;
-import static gov.va.api.health.dataquery.service.controller.Transformers.ifPresent;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.allBlank;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateTimeString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convert;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convertAll;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.ifPresent;
 
 import gov.va.api.health.dataquery.service.controller.EnumSearcher;
 import gov.va.api.health.dstu2.api.datatypes.CodeableConcept;

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/Dstu2ImmunizationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/Dstu2ImmunizationController.java
@@ -5,12 +5,12 @@ import static java.util.Collections.emptyList;
 import gov.va.api.health.argonaut.api.resources.Immunization;
 import gov.va.api.health.argonaut.api.resources.Immunization.Bundle;
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
 import gov.va.api.health.dataquery.service.controller.CountParameter;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks;
 import gov.va.api.health.dataquery.service.controller.Parameters;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions.NotFound;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dstu2.api.resources.OperationOutcome;
 import java.util.Collection;
@@ -50,7 +50,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class Dstu2ImmunizationController {
 
-  private Bundler bundler;
+  private Dstu2Bundler bundler;
 
   private ImmunizationRepository repository;
 
@@ -59,7 +59,7 @@ public class Dstu2ImmunizationController {
   /** Spring constructor. */
   @SuppressWarnings("ParameterHidesMemberVariable")
   public Dstu2ImmunizationController(
-      @Autowired Bundler bundler,
+      @Autowired Dstu2Bundler bundler,
       @Autowired ImmunizationRepository repository,
       @Autowired WitnessProtection witnessProtection) {
     this.bundler = bundler;
@@ -78,7 +78,7 @@ public class Dstu2ImmunizationController {
             .totalRecords(totalRecords)
             .build();
     return bundler.bundle(
-        Bundler.BundleContext.of(
+        Dstu2Bundler.BundleContext.of(
             linkConfig,
             reports,
             Function.identity(),
@@ -195,6 +195,6 @@ public class Dstu2ImmunizationController {
     consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
   )
   public OperationOutcome validate(@RequestBody Immunization.Bundle bundle) {
-    return Validator.create().validate(bundle);
+    return Dstu2Validator.create().validate(bundle);
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/Dstu2ImmunizationIncludesIcnMajig.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/Dstu2ImmunizationIncludesIcnMajig.java
@@ -2,7 +2,7 @@ package gov.va.api.health.dataquery.service.controller.immunization;
 
 import gov.va.api.health.argonaut.api.resources.Immunization;
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Transformers;
+import gov.va.api.health.dataquery.service.controller.Dstu2Transformers;
 import java.util.stream.Stream;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 
@@ -19,6 +19,6 @@ public class Dstu2ImmunizationIncludesIcnMajig
     super(
         Immunization.class,
         Immunization.Bundle.class,
-        body -> Stream.ofNullable(Transformers.asReferenceId(body.patient())));
+        body -> Stream.ofNullable(Dstu2Transformers.asReferenceId(body.patient())));
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/Dstu2ImmunizationTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/Dstu2ImmunizationTransformer.java
@@ -1,7 +1,7 @@
 package gov.va.api.health.dataquery.service.controller.immunization;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateTimeString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asReference;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateTimeString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asReference;
 
 import gov.va.api.health.argonaut.api.resources.Immunization;
 import gov.va.api.health.dataquery.service.controller.datamart.DatamartReference;

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/location/DatamartLocationTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/location/DatamartLocationTransformer.java
@@ -1,7 +1,7 @@
 package gov.va.api.health.dataquery.service.controller.location;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.allBlank;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asReference;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.allBlank;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asReference;
 import static java.util.Arrays.asList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/location/LocationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/location/LocationController.java
@@ -1,18 +1,18 @@
 package gov.va.api.health.dataquery.service.controller.location;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.firstPayloadItem;
-import static gov.va.api.health.dataquery.service.controller.Transformers.hasPayload;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.firstPayloadItem;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.hasPayload;
 import static java.util.Collections.emptyList;
 
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
 import gov.va.api.health.dataquery.service.controller.CountParameter;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
@@ -61,7 +61,7 @@ public class LocationController {
 
   private MrAndersonClient mrAndersonClient;
 
-  private Bundler bundler;
+  private Dstu2Bundler bundler;
 
   private LocationRepository repository;
 
@@ -74,7 +74,7 @@ public class LocationController {
       @Value("${datamart.location}") boolean defaultToDatamart,
       @Autowired Transformer transformer,
       @Autowired MrAndersonClient mrAndersonClient,
-      @Autowired Bundler bundler,
+      @Autowired Dstu2Bundler bundler,
       @Autowired LocationRepository repository,
       @Autowired WitnessProtection witnessProtection) {
     this.defaultToDatamart = defaultToDatamart;
@@ -180,7 +180,7 @@ public class LocationController {
     consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
   )
   public OperationOutcome validate(@RequestBody Location.Bundle bundle) {
-    return Validator.create().validate(bundle);
+    return Dstu2Validator.create().validate(bundle);
   }
 
   public interface Transformer
@@ -203,7 +203,7 @@ public class LocationController {
               .totalRecords(totalRecords)
               .build();
       return bundler.bundle(
-          Bundler.BundleContext.of(
+          Dstu2Bundler.BundleContext.of(
               linkConfig, reports, Function.identity(), Location.Entry::new, Location.Bundle::new));
     }
 

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/location/LocationTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/location/LocationTransformer.java
@@ -1,9 +1,9 @@
 package gov.va.api.health.dataquery.service.controller.location;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.allBlank;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convert;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convertAll;
-import static gov.va.api.health.dataquery.service.controller.Transformers.ifPresent;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.allBlank;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convert;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convertAll;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.ifPresent;
 
 import gov.va.api.health.dataquery.service.controller.EnumSearcher;
 import gov.va.api.health.dstu2.api.datatypes.Address;

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medication/Dstu2MedicationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medication/Dstu2MedicationController.java
@@ -6,12 +6,12 @@ import gov.va.api.health.argonaut.api.resources.Medication;
 import gov.va.api.health.argonaut.api.resources.Medication.Bundle;
 import gov.va.api.health.argonaut.api.resources.Medication.Entry;
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
 import gov.va.api.health.dataquery.service.controller.CountParameter;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks;
 import gov.va.api.health.dataquery.service.controller.Parameters;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dstu2.api.resources.OperationOutcome;
 import java.util.List;
@@ -45,7 +45,7 @@ import org.springframework.web.bind.annotation.RestController;
 )
 public class Dstu2MedicationController {
 
-  private Bundler bundler;
+  private Dstu2Bundler bundler;
 
   private MedicationRepository repository;
 
@@ -54,7 +54,7 @@ public class Dstu2MedicationController {
   /** Spring constructor. */
   @SuppressWarnings("ParameterHidesMemberVariable")
   public Dstu2MedicationController(
-      @Autowired Bundler bundler,
+      @Autowired Dstu2Bundler bundler,
       @Autowired MedicationRepository repository,
       @Autowired WitnessProtection witnessProtection) {
     this.bundler = bundler;
@@ -73,7 +73,7 @@ public class Dstu2MedicationController {
             .totalRecords(totalRecords)
             .build();
     return bundler.bundle(
-        Bundler.BundleContext.of(
+        Dstu2Bundler.BundleContext.of(
             linkConfig, reports, Function.identity(), Entry::new, Bundle::new));
   }
 
@@ -128,6 +128,6 @@ public class Dstu2MedicationController {
     consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
   )
   public OperationOutcome validate(@RequestBody Bundle bundle) {
-    return Validator.create().validate(bundle);
+    return Dstu2Validator.create().validate(bundle);
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationdispense/MedicationDispenseController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationdispense/MedicationDispenseController.java
@@ -1,14 +1,14 @@
 package gov.va.api.health.dataquery.service.controller.medicationdispense;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.firstPayloadItem;
-import static gov.va.api.health.dataquery.service.controller.Transformers.hasPayload;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.firstPayloadItem;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.hasPayload;
 
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
 import gov.va.api.health.dataquery.service.controller.CountParameter;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
 import gov.va.api.health.dstu2.api.resources.MedicationDispense;
@@ -42,7 +42,7 @@ public class MedicationDispenseController {
 
   private MrAndersonClient mrAndersonClient;
 
-  private Bundler bundler;
+  private Dstu2Bundler bundler;
 
   private MedicationDispense.Bundle bundle(
       MultiValueMap<String, String> parameters, int page, int count) {
@@ -170,7 +170,7 @@ public class MedicationDispenseController {
     consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
   )
   public OperationOutcome validate(@RequestBody MedicationDispense.Bundle bundle) {
-    return Validator.create().validate(bundle);
+    return Dstu2Validator.create().validate(bundle);
   }
 
   public interface Transformer

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationdispense/MedicationDispenseIncludesIcnMajig.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationdispense/MedicationDispenseIncludesIcnMajig.java
@@ -1,7 +1,7 @@
 package gov.va.api.health.dataquery.service.controller.medicationdispense;
 
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Transformers;
+import gov.va.api.health.dataquery.service.controller.Dstu2Transformers;
 import gov.va.api.health.dstu2.api.resources.MedicationDispense;
 import java.util.stream.Stream;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -20,6 +20,6 @@ public class MedicationDispenseIncludesIcnMajig
     super(
         MedicationDispense.class,
         MedicationDispense.Bundle.class,
-        body -> Stream.ofNullable(Transformers.asReferenceId(body.patient())));
+        body -> Stream.ofNullable(Dstu2Transformers.asReferenceId(body.patient())));
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationdispense/MedicationDispenseTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationdispense/MedicationDispenseTransformer.java
@@ -1,10 +1,10 @@
 package gov.va.api.health.dataquery.service.controller.medicationdispense;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.allBlank;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateTimeString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convert;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convertAll;
-import static gov.va.api.health.dataquery.service.controller.Transformers.ifPresent;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.allBlank;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateTimeString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convert;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convertAll;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.ifPresent;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import gov.va.api.health.dataquery.service.controller.EnumSearcher;

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/Dstu2MedicationOrderController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/Dstu2MedicationOrderController.java
@@ -5,12 +5,12 @@ import static java.util.Collections.emptyList;
 import gov.va.api.health.argonaut.api.resources.MedicationOrder;
 import gov.va.api.health.argonaut.api.resources.MedicationOrder.Bundle;
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
 import gov.va.api.health.dataquery.service.controller.CountParameter;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks;
 import gov.va.api.health.dataquery.service.controller.Parameters;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dstu2.api.resources.OperationOutcome;
 import java.util.Collection;
@@ -50,7 +50,7 @@ import org.springframework.web.bind.annotation.RestController;
 )
 public class Dstu2MedicationOrderController {
 
-  private Bundler bundler;
+  private Dstu2Bundler bundler;
 
   private MedicationOrderRepository repository;
 
@@ -58,7 +58,7 @@ public class Dstu2MedicationOrderController {
 
   /** All args constructor. */
   public Dstu2MedicationOrderController(
-      @Autowired Bundler bundler,
+      @Autowired Dstu2Bundler bundler,
       @Autowired MedicationOrderRepository repository,
       @Autowired WitnessProtection witnessProtection) {
     this.bundler = bundler;
@@ -77,7 +77,7 @@ public class Dstu2MedicationOrderController {
             .totalRecords(totalRecords)
             .build();
     return bundler.bundle(
-        Bundler.BundleContext.of(
+        Dstu2Bundler.BundleContext.of(
             linkConfig,
             results,
             Function.identity(),
@@ -186,6 +186,6 @@ public class Dstu2MedicationOrderController {
     consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
   )
   public OperationOutcome validate(@RequestBody MedicationOrder.Bundle bundle) {
-    return Validator.create().validate(bundle);
+    return Dstu2Validator.create().validate(bundle);
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/Dstu2MedicationOrderIncludesIcnMajig.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/Dstu2MedicationOrderIncludesIcnMajig.java
@@ -2,7 +2,7 @@ package gov.va.api.health.dataquery.service.controller.medicationorder;
 
 import gov.va.api.health.argonaut.api.resources.MedicationOrder;
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Transformers;
+import gov.va.api.health.dataquery.service.controller.Dstu2Transformers;
 import java.util.stream.Stream;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 
@@ -20,6 +20,6 @@ public class Dstu2MedicationOrderIncludesIcnMajig
     super(
         MedicationOrder.class,
         MedicationOrder.Bundle.class,
-        body -> Stream.ofNullable(Transformers.asReferenceId(body.patient())));
+        body -> Stream.ofNullable(Dstu2Transformers.asReferenceId(body.patient())));
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/Dstu2MedicationOrderTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/Dstu2MedicationOrderTransformer.java
@@ -1,7 +1,7 @@
 package gov.va.api.health.dataquery.service.controller.medicationorder;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateTimeString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asReference;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateTimeString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asReference;
 
 import com.google.common.collect.ImmutableMap;
 import gov.va.api.health.argonaut.api.resources.MedicationOrder;

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationstatement/DatamartMedicationStatementTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationstatement/DatamartMedicationStatementTransformer.java
@@ -1,7 +1,7 @@
 package gov.va.api.health.dataquery.service.controller.medicationstatement;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateTimeString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asReference;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateTimeString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asReference;
 
 import gov.va.api.health.argonaut.api.resources.MedicationStatement;
 import gov.va.api.health.dstu2.api.datatypes.CodeableConcept;

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationstatement/MedicationStatementController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationstatement/MedicationStatementController.java
@@ -1,20 +1,20 @@
 package gov.va.api.health.dataquery.service.controller.medicationstatement;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.firstPayloadItem;
-import static gov.va.api.health.dataquery.service.controller.Transformers.hasPayload;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.firstPayloadItem;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.hasPayload;
 import static java.util.Collections.emptyList;
 
 import gov.va.api.health.argonaut.api.resources.MedicationStatement;
 import gov.va.api.health.argonaut.api.resources.MedicationStatement.Bundle;
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
 import gov.va.api.health.dataquery.service.controller.CountParameter;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions.NotFound;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
@@ -67,7 +67,7 @@ public class MedicationStatementController {
 
   private MrAndersonClient mrAndersonClient;
 
-  private Bundler bundler;
+  private Dstu2Bundler bundler;
 
   private WitnessProtection witnessProtection;
 
@@ -81,7 +81,7 @@ public class MedicationStatementController {
       @Value("${datamart.medication-statement}") boolean defaultToDatamart,
       @Autowired MedicationStatementController.Transformer transformer,
       @Autowired MrAndersonClient mrAndersonClient,
-      @Autowired Bundler bundler,
+      @Autowired Dstu2Bundler bundler,
       @Autowired MedicationStatementRepository repository,
       @Autowired WitnessProtection witnessProtection) {
     this.defaultToDatamart = defaultToDatamart;
@@ -202,7 +202,7 @@ public class MedicationStatementController {
     consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
   )
   public OperationOutcome validate(@RequestBody MedicationStatement.Bundle bundle) {
-    return Validator.create().validate(bundle);
+    return Dstu2Validator.create().validate(bundle);
   }
 
   public interface Transformer
@@ -230,7 +230,7 @@ public class MedicationStatementController {
               .totalRecords(totalRecords)
               .build();
       return bundler.bundle(
-          Bundler.BundleContext.of(
+          Dstu2Bundler.BundleContext.of(
               linkConfig,
               reports,
               Function.identity(),

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationstatement/MedicationStatementIncludesIcnMajig.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationstatement/MedicationStatementIncludesIcnMajig.java
@@ -2,7 +2,7 @@ package gov.va.api.health.dataquery.service.controller.medicationstatement;
 
 import gov.va.api.health.argonaut.api.resources.MedicationStatement;
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Transformers;
+import gov.va.api.health.dataquery.service.controller.Dstu2Transformers;
 import java.util.stream.Stream;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 
@@ -20,6 +20,6 @@ public class MedicationStatementIncludesIcnMajig
     super(
         MedicationStatement.class,
         MedicationStatement.Bundle.class,
-        body -> Stream.ofNullable(Transformers.asReferenceId(body.patient())));
+        body -> Stream.ofNullable(Dstu2Transformers.asReferenceId(body.patient())));
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationstatement/MedicationStatementTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationstatement/MedicationStatementTransformer.java
@@ -1,10 +1,10 @@
 package gov.va.api.health.dataquery.service.controller.medicationstatement;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.allBlank;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateTimeString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convert;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convertAll;
-import static gov.va.api.health.dataquery.service.controller.Transformers.ifPresent;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.allBlank;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateTimeString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convert;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convertAll;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.ifPresent;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import gov.va.api.health.argonaut.api.resources.MedicationStatement;

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/DatamartObservationTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/DatamartObservationTransformer.java
@@ -1,10 +1,10 @@
 package gov.va.api.health.dataquery.service.controller.observation;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.allBlank;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asCoding;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateTimeString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asReference;
-import static gov.va.api.health.dataquery.service.controller.Transformers.emptyToNull;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.allBlank;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asCoding;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateTimeString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asReference;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.emptyToNull;
 import static java.util.Arrays.asList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/ObservationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/ObservationController.java
@@ -1,7 +1,7 @@
 package gov.va.api.health.dataquery.service.controller.observation;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.firstPayloadItem;
-import static gov.va.api.health.dataquery.service.controller.Transformers.hasPayload;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.firstPayloadItem;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.hasPayload;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -9,13 +9,13 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import com.google.common.base.Splitter;
 import gov.va.api.health.argonaut.api.resources.Observation;
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
 import gov.va.api.health.dataquery.service.controller.CountParameter;
 import gov.va.api.health.dataquery.service.controller.DateTimeParameter;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks;
 import gov.va.api.health.dataquery.service.controller.Parameters;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
@@ -69,7 +69,7 @@ public class ObservationController {
 
   private MrAndersonClient mrAndersonClient;
 
-  private Bundler bundler;
+  private Dstu2Bundler bundler;
 
   private WitnessProtection witnessProtection;
 
@@ -80,7 +80,7 @@ public class ObservationController {
       @Value("${datamart.observation}") boolean defaultToDatamart,
       @Autowired Transformer transformer,
       @Autowired MrAndersonClient mrAndersonClient,
-      @Autowired Bundler bundler,
+      @Autowired Dstu2Bundler bundler,
       @Autowired ObservationRepository repository,
       @Autowired WitnessProtection witnessProtection) {
     this.defaultToDatamart = defaultToDatamart;
@@ -103,7 +103,7 @@ public class ObservationController {
             .totalRecords(root.getRecordCount().intValue())
             .build();
     return bundler.bundle(
-        Bundler.BundleContext.of(
+        Dstu2Bundler.BundleContext.of(
             linkConfig,
             root.getObservations() == null ? emptyList() : root.getObservations().getObservation(),
             transformer,
@@ -248,7 +248,7 @@ public class ObservationController {
     consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
   )
   public OperationOutcome validate(@RequestBody Observation.Bundle bundle) {
-    return Validator.create().validate(bundle);
+    return Dstu2Validator.create().validate(bundle);
   }
 
   public interface Transformer
@@ -271,7 +271,7 @@ public class ObservationController {
               .totalRecords(totalRecords)
               .build();
       return bundler.bundle(
-          Bundler.BundleContext.of(
+          Dstu2Bundler.BundleContext.of(
               linkConfig,
               records,
               Function.identity(),

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/ObservationIncludesIcnMajig.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/ObservationIncludesIcnMajig.java
@@ -2,7 +2,7 @@ package gov.va.api.health.dataquery.service.controller.observation;
 
 import gov.va.api.health.argonaut.api.resources.Observation;
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Transformers;
+import gov.va.api.health.dataquery.service.controller.Dstu2Transformers;
 import java.util.stream.Stream;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 
@@ -19,6 +19,6 @@ public class ObservationIncludesIcnMajig
     super(
         Observation.class,
         Observation.Bundle.class,
-        (body) -> Stream.ofNullable(Transformers.asReferenceId(body.subject())));
+        (body) -> Stream.ofNullable(Dstu2Transformers.asReferenceId(body.subject())));
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/ObservationTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/ObservationTransformer.java
@@ -1,10 +1,10 @@
 package gov.va.api.health.dataquery.service.controller.observation;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.allBlank;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateTimeString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convert;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convertAll;
-import static gov.va.api.health.dataquery.service.controller.Transformers.ifPresent;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.allBlank;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateTimeString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convert;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convertAll;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.ifPresent;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import gov.va.api.health.argonaut.api.resources.Observation;

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/organization/OrganizationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/organization/OrganizationController.java
@@ -1,14 +1,14 @@
 package gov.va.api.health.dataquery.service.controller.organization;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.firstPayloadItem;
-import static gov.va.api.health.dataquery.service.controller.Transformers.hasPayload;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.firstPayloadItem;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.hasPayload;
 
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
 import gov.va.api.health.dataquery.service.controller.CountParameter;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
 import gov.va.api.health.dataquery.service.mranderson.client.Query.Profile;
@@ -45,7 +45,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrganizationController {
   private Transformer transformer;
   private MrAndersonClient mrAndersonClient;
-  private Bundler bundler;
+  private Dstu2Bundler bundler;
 
   private Organization.Bundle bundle(
       MultiValueMap<String, String> parameters, int page, int count) {
@@ -123,7 +123,7 @@ public class OrganizationController {
     consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
   )
   public OperationOutcome validate(@RequestBody Organization.Bundle bundle) {
-    return Validator.create().validate(bundle);
+    return Dstu2Validator.create().validate(bundle);
   }
 
   public interface Transformer

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/organization/OrganizationTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/organization/OrganizationTransformer.java
@@ -1,9 +1,9 @@
 package gov.va.api.health.dataquery.service.controller.organization;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.allBlank;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convert;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convertAll;
-import static gov.va.api.health.dataquery.service.controller.Transformers.ifPresent;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.allBlank;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convert;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convertAll;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.ifPresent;
 import static java.util.Collections.singletonList;
 
 import gov.va.api.health.dataquery.service.controller.EnumSearcher;

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/DatamartPatientTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/DatamartPatientTransformer.java
@@ -1,8 +1,8 @@
 package gov.va.api.health.dataquery.service.controller.patient;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.allBlank;
-import static gov.va.api.health.dataquery.service.controller.Transformers.emptyToNull;
-import static gov.va.api.health.dataquery.service.controller.Transformers.parseInstant;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.allBlank;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.emptyToNull;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.parseInstant;
 import static java.util.Arrays.asList;
 import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
 import static org.apache.commons.lang3.StringUtils.isBlank;

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/PatientController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/PatientController.java
@@ -1,17 +1,17 @@
 package gov.va.api.health.dataquery.service.controller.patient;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.firstPayloadItem;
-import static gov.va.api.health.dataquery.service.controller.Transformers.hasPayload;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.firstPayloadItem;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.hasPayload;
 import static java.util.Collections.emptyList;
 
 import gov.va.api.health.argonaut.api.resources.Patient;
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
 import gov.va.api.health.dataquery.service.controller.CountParameter;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks;
 import gov.va.api.health.dataquery.service.controller.Parameters;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
@@ -62,7 +62,7 @@ public class PatientController {
 
   private MrAndersonClient mrAndersonClient;
 
-  private Bundler bundler;
+  private Dstu2Bundler bundler;
 
   private PatientSearchRepository repository;
 
@@ -75,7 +75,7 @@ public class PatientController {
       @Value("${datamart.patient}") boolean defaultToDatamart,
       @Autowired Transformer transformer,
       @Autowired MrAndersonClient mrAndersonClient,
-      @Autowired Bundler bundler,
+      @Autowired Dstu2Bundler bundler,
       @Autowired PatientSearchRepository repository,
       @Autowired WitnessProtection witnessProtection) {
     this.defaultToDatamart = defaultToDatamart;
@@ -97,7 +97,7 @@ public class PatientController {
             .totalRecords(root.getRecordCount())
             .build();
     return bundler.bundle(
-        Bundler.BundleContext.of(
+        Dstu2Bundler.BundleContext.of(
             linkConfig,
             root.getPatients() == null ? Collections.emptyList() : root.getPatients().getPatient(),
             transformer,
@@ -251,7 +251,7 @@ public class PatientController {
     consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
   )
   public OperationOutcome validate(@RequestBody Patient.Bundle bundle) {
-    return Validator.create().validate(bundle);
+    return Dstu2Validator.create().validate(bundle);
   }
 
   public interface Transformer
@@ -274,7 +274,7 @@ public class PatientController {
               .totalRecords(totalRecords)
               .build();
       return bundler.bundle(
-          Bundler.BundleContext.of(
+          Dstu2Bundler.BundleContext.of(
               linkConfig, reports, Function.identity(), Patient.Entry::new, Patient.Bundle::new));
     }
 

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/PatientTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/PatientTransformer.java
@@ -1,11 +1,11 @@
 package gov.va.api.health.dataquery.service.controller.patient;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.allBlank;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateTimeString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convert;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convertAll;
-import static gov.va.api.health.dataquery.service.controller.Transformers.ifPresent;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.allBlank;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateTimeString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convert;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convertAll;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.ifPresent;
 import static java.util.Collections.singletonList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/PractitionerController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/PractitionerController.java
@@ -1,14 +1,14 @@
 package gov.va.api.health.dataquery.service.controller.practitioner;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.firstPayloadItem;
-import static gov.va.api.health.dataquery.service.controller.Transformers.hasPayload;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.firstPayloadItem;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.hasPayload;
 
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
 import gov.va.api.health.dataquery.service.controller.CountParameter;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
 import gov.va.api.health.dataquery.service.mranderson.client.Query.Profile;
@@ -45,7 +45,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PractitionerController {
   private Transformer transformer;
   private MrAndersonClient mrAndersonClient;
-  private Bundler bundler;
+  private Dstu2Bundler bundler;
 
   private Practitioner.Bundle bundle(
       MultiValueMap<String, String> parameters, int page, int count) {
@@ -123,7 +123,7 @@ public class PractitionerController {
     consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
   )
   public OperationOutcome validate(@RequestBody Practitioner.Bundle bundle) {
-    return Validator.create().validate(bundle);
+    return Dstu2Validator.create().validate(bundle);
   }
 
   public interface Transformer

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/PractitionerTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/PractitionerTransformer.java
@@ -1,10 +1,10 @@
 package gov.va.api.health.dataquery.service.controller.practitioner;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.allBlank;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateTimeString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convert;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convertAll;
-import static gov.va.api.health.dataquery.service.controller.Transformers.ifPresent;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.allBlank;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateTimeString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convert;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convertAll;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.ifPresent;
 import static java.util.Collections.singletonList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/procedure/DatamartProcedureTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/procedure/DatamartProcedureTransformer.java
@@ -1,8 +1,8 @@
 package gov.va.api.health.dataquery.service.controller.procedure;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.asCodeableConceptWrapping;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateTimeString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asReference;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asCodeableConceptWrapping;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateTimeString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asReference;
 
 import gov.va.api.health.argonaut.api.resources.Procedure;
 import gov.va.api.health.argonaut.api.resources.Procedure.Status;

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/procedure/ProcedureController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/procedure/ProcedureController.java
@@ -1,7 +1,7 @@
 package gov.va.api.health.dataquery.service.controller.procedure;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.firstPayloadItem;
-import static gov.va.api.health.dataquery.service.controller.Transformers.hasPayload;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.firstPayloadItem;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.hasPayload;
 import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -10,15 +10,15 @@ import gov.va.api.health.argonaut.api.resources.Procedure;
 import gov.va.api.health.argonaut.api.resources.Procedure.Bundle;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
 import gov.va.api.health.dataquery.service.controller.CountParameter;
 import gov.va.api.health.dataquery.service.controller.DateTimeParameter;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions.NotFound;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dataquery.service.controller.procedure.ProcedureRepository.PatientAndDateSpecification;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
@@ -94,7 +94,7 @@ public class ProcedureController {
 
   private MrAndersonClient mrAndersonClient;
 
-  private Bundler bundler;
+  private Dstu2Bundler bundler;
 
   private ProcedureRepository repository;
 
@@ -112,7 +112,7 @@ public class ProcedureController {
           String withoutRecordsDisplay,
       Transformer transformer,
       MrAndersonClient mrAndersonClient,
-      Bundler bundler,
+      Dstu2Bundler bundler,
       ProcedureRepository repository,
       WitnessProtection witnessProtection) {
     this.defaultToDatamart = defaultToDatamart;
@@ -306,7 +306,7 @@ public class ProcedureController {
     consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
   )
   public OperationOutcome validate(@RequestBody Procedure.Bundle bundle) {
-    return Validator.create().validate(bundle);
+    return Dstu2Validator.create().validate(bundle);
   }
 
   public interface Transformer
@@ -330,7 +330,7 @@ public class ProcedureController {
               .totalRecords(totalRecords)
               .build();
       return bundler.bundle(
-          Bundler.BundleContext.of(
+          Dstu2Bundler.BundleContext.of(
               linkConfig,
               reports,
               Function.identity(),

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/procedure/ProcedureIncludesIcnMajig.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/procedure/ProcedureIncludesIcnMajig.java
@@ -2,7 +2,7 @@ package gov.va.api.health.dataquery.service.controller.procedure;
 
 import gov.va.api.health.argonaut.api.resources.Procedure;
 import gov.va.api.health.dataquery.service.controller.AbstractIncludesIcnMajig;
-import gov.va.api.health.dataquery.service.controller.Transformers;
+import gov.va.api.health.dataquery.service.controller.Dstu2Transformers;
 import java.util.stream.Stream;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 
@@ -19,6 +19,6 @@ public class ProcedureIncludesIcnMajig
     super(
         Procedure.class,
         Procedure.Bundle.class,
-        body -> Stream.ofNullable(Transformers.asReferenceId(body.subject())));
+        body -> Stream.ofNullable(Dstu2Transformers.asReferenceId(body.subject())));
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/procedure/ProcedureTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/procedure/ProcedureTransformer.java
@@ -1,10 +1,10 @@
 package gov.va.api.health.dataquery.service.controller.procedure;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.allBlank;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateTimeString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convert;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convertAll;
-import static gov.va.api.health.dataquery.service.controller.Transformers.ifPresent;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.allBlank;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateTimeString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convert;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convertAll;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.ifPresent;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import gov.va.api.health.argonaut.api.resources.Procedure;

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/Dstu2BundlerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/Dstu2BundlerTest.java
@@ -3,7 +3,7 @@ package gov.va.api.health.dataquery.service.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dstu2.api.bundle.AbstractBundle;
 import gov.va.api.health.dstu2.api.bundle.AbstractBundle.BundleType;
@@ -27,17 +27,17 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 @SuppressWarnings("WeakerAccess")
-public class BundlerTest {
+public class Dstu2BundlerTest {
   private static final Function<FugaziCdwRoot, FugaziArgo> FUGAZIMUS_PRIME =
       x -> FugaziArgo.of(x.id());
 
   @Mock PageLinks links;
-  Bundler bundler;
+  Dstu2Bundler bundler;
 
   @Before
   public void _init() {
     MockitoAnnotations.initMocks(this);
-    bundler = new Bundler(links);
+    bundler = new Dstu2Bundler(links);
   }
 
   @Test

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/Dstu2TransformersTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/Dstu2TransformersTest.java
@@ -1,23 +1,23 @@
 package gov.va.api.health.dataquery.service.controller;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.asCodeableConceptWrapping;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asCoding;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDatamartReference;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asDateTimeString;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asInteger;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asReference;
-import static gov.va.api.health.dataquery.service.controller.Transformers.asReferenceId;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convert;
-import static gov.va.api.health.dataquery.service.controller.Transformers.convertAll;
-import static gov.va.api.health.dataquery.service.controller.Transformers.emptyToNull;
-import static gov.va.api.health.dataquery.service.controller.Transformers.firstPayloadItem;
-import static gov.va.api.health.dataquery.service.controller.Transformers.hasPayload;
-import static gov.va.api.health.dataquery.service.controller.Transformers.ifPresent;
-import static gov.va.api.health.dataquery.service.controller.Transformers.isBlank;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asCodeableConceptWrapping;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asCoding;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDatamartReference;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asDateTimeString;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asInteger;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asReference;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.asReferenceId;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convert;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.convertAll;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.emptyToNull;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.firstPayloadItem;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.hasPayload;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.ifPresent;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.isBlank;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import gov.va.api.health.dataquery.service.controller.Transformers.MissingPayload;
+import gov.va.api.health.dataquery.service.controller.Dstu2Transformers.MissingPayload;
 import gov.va.api.health.dataquery.service.controller.datamart.DatamartCoding;
 import gov.va.api.health.dataquery.service.controller.datamart.DatamartReference;
 import gov.va.api.health.dstu2.api.datatypes.CodeableConcept;
@@ -37,15 +37,15 @@ import javax.xml.datatype.XMLGregorianCalendar;
 import lombok.SneakyThrows;
 import org.junit.Test;
 
-public class TransformersTest {
+public class Dstu2TransformersTest {
 
   @Test
   public void allBlank() {
-    assertThat(Transformers.allBlank()).isTrue();
-    assertThat(Transformers.allBlank(null, null, null, null)).isTrue();
-    assertThat(Transformers.allBlank(null, "", " ")).isTrue();
-    assertThat(Transformers.allBlank(null, 1, null, null)).isFalse();
-    assertThat(Transformers.allBlank(1, "x", "z", 2.0)).isFalse();
+    assertThat(Dstu2Transformers.allBlank()).isTrue();
+    assertThat(Dstu2Transformers.allBlank(null, null, null, null)).isTrue();
+    assertThat(Dstu2Transformers.allBlank(null, "", " ")).isTrue();
+    assertThat(Dstu2Transformers.allBlank(null, 1, null, null)).isFalse();
+    assertThat(Dstu2Transformers.allBlank(1, "x", "z", 2.0)).isFalse();
   }
 
   @Test

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/WebExceptionHandlerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/WebExceptionHandlerTest.java
@@ -57,7 +57,7 @@ public class WebExceptionHandlerTest {
   @Mock HttpServletRequest request;
   @Mock MrAndersonClient mrAnderson;
   @Mock PatientController.Transformer tx;
-  @Mock Bundler bundler;
+  @Mock Dstu2Bundler bundler;
   private PatientController controller;
   private WebExceptionHandler exceptionHandler;
 

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/Dstu2AllergyIntoleranceControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/Dstu2AllergyIntoleranceControllerTest.java
@@ -10,8 +10,8 @@ import com.google.common.collect.Multimap;
 import gov.va.api.health.argonaut.api.resources.AllergyIntolerance;
 import gov.va.api.health.argonaut.api.resources.AllergyIntolerance.Bundle;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
 import gov.va.api.health.dataquery.service.controller.ConfigurableBaseUrlPageLinks;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dataquery.service.controller.allergyintolerance.AllergyIntoleranceSamples.Datamart;
@@ -55,7 +55,7 @@ public class Dstu2AllergyIntoleranceControllerTest {
 
   Dstu2AllergyIntoleranceController controller() {
     return new Dstu2AllergyIntoleranceController(
-        new Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
+        new Dstu2Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
         repository,
         WitnessProtection.builder().identityService(ids).build());
   }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/appointment/AppointmentControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/appointment/AppointmentControllerTest.java
@@ -5,11 +5,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
 import gov.va.api.health.dstu2.api.bundle.AbstractBundle.BundleType;
@@ -39,7 +39,7 @@ public class AppointmentControllerTest {
   @Mock AppointmentController.Transformer tx;
 
   AppointmentController controller;
-  @Mock Bundler bundler;
+  @Mock Dstu2Bundler bundler;
 
   @Before
   public void _init() {
@@ -153,7 +153,7 @@ public class AppointmentControllerTest {
                 Appointment.class);
 
     Bundle bundle = bundleOf(resource);
-    assertThat(controller.validate(bundle)).isEqualTo(Validator.ok());
+    assertThat(controller.validate(bundle)).isEqualTo(Dstu2Validator.ok());
   }
 
   @Test(expected = ConstraintViolationException.class)

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/condition/ConditionControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/condition/ConditionControllerTest.java
@@ -8,11 +8,11 @@ import gov.va.api.health.argonaut.api.resources.Condition;
 import gov.va.api.health.argonaut.api.resources.Condition.Bundle;
 import gov.va.api.health.argonaut.api.resources.Condition.Entry;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
 import gov.va.api.health.dstu2.api.bundle.AbstractBundle.BundleType;
@@ -39,7 +39,7 @@ public class ConditionControllerTest {
   @Mock ConditionController.Transformer transformer;
 
   ConditionController controller;
-  @Mock Bundler bundler;
+  @Mock Dstu2Bundler bundler;
 
   @Before
   public void _init() {
@@ -173,7 +173,7 @@ public class ConditionControllerTest {
                 getClass().getResourceAsStream("/cdw/old-condition-1.03.json"), Condition.class);
 
     Bundle bundle = bundleOf(resource);
-    assertThat(controller.validate(bundle)).isEqualTo(Validator.ok());
+    assertThat(controller.validate(bundle)).isEqualTo(Dstu2Validator.ok());
   }
 
   @Test(expected = ConstraintViolationException.class)

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/condition/DatamartConditionControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/condition/DatamartConditionControllerTest.java
@@ -12,8 +12,8 @@ import gov.va.api.health.argonaut.api.resources.Condition;
 import gov.va.api.health.argonaut.api.resources.Condition.Bundle;
 import gov.va.api.health.argonaut.api.resources.Condition.ClinicalStatusCode;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
 import gov.va.api.health.dataquery.service.controller.ConfigurableBaseUrlPageLinks;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dataquery.service.controller.condition.DatamartCondition.Category;
@@ -65,7 +65,7 @@ public class DatamartConditionControllerTest {
         true,
         null,
         null,
-        new Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
+        new Dstu2Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
         repository,
         WitnessProtection.builder().identityService(ids).build());
   }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/DatamartDiagnosticReportTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/DatamartDiagnosticReportTest.java
@@ -1,7 +1,7 @@
 package gov.va.api.health.dataquery.service.controller.diagnosticreport;
 
 import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
-import static gov.va.api.health.dataquery.service.controller.Transformers.parseInstant;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.parseInstant;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -10,8 +10,8 @@ import static org.mockito.Mockito.verify;
 import com.google.common.collect.Iterables;
 import gov.va.api.health.argonaut.api.resources.DiagnosticReport;
 import gov.va.api.health.argonaut.api.resources.DiagnosticReport.Bundle;
-import gov.va.api.health.dataquery.service.controller.Bundler;
 import gov.va.api.health.dataquery.service.controller.ConfigurableBaseUrlPageLinks;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dataquery.service.controller.diagnosticreport.DatamartDiagnosticReports.Result;
@@ -53,7 +53,7 @@ public final class DatamartDiagnosticReportTest {
         true,
         null,
         null,
-        new Bundler(new ConfigurableBaseUrlPageLinks("", "")),
+        new Dstu2Bundler(new ConfigurableBaseUrlPageLinks("", "")),
         WitnessProtection.builder().identityService(mock(IdentityService.class)).build(),
         entityManager.getEntityManager());
   }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/DiagnosticReportControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/DiagnosticReportControllerTest.java
@@ -8,11 +8,11 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.Iterables;
 import gov.va.api.health.argonaut.api.resources.DiagnosticReport;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
 import gov.va.api.health.dataquery.service.controller.ConfigurableBaseUrlPageLinks;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
 import gov.va.api.health.dstu2.api.bundle.AbstractBundle.BundleType;
@@ -33,7 +33,7 @@ import org.springframework.util.MultiValueMap;
 public class DiagnosticReportControllerTest {
   @Mock MrAndersonClient mraClient;
   @Mock DiagnosticReportController.Transformer tx;
-  @Mock Bundler bundler;
+  @Mock Dstu2Bundler bundler;
 
   DiagnosticReportController controller;
 
@@ -74,10 +74,10 @@ public class DiagnosticReportControllerTest {
 
     @SuppressWarnings("unchecked")
     ArgumentCaptor<
-            Bundler.BundleContext<
+            Dstu2Bundler.BundleContext<
                 CdwDiagnosticReport102Root.CdwDiagnosticReports.CdwDiagnosticReport,
                 DiagnosticReport, DiagnosticReport.Entry, DiagnosticReport.Bundle>>
-        captor = ArgumentCaptor.forClass(Bundler.BundleContext.class);
+        captor = ArgumentCaptor.forClass(Dstu2Bundler.BundleContext.class);
 
     verify(bundler).bundle(captor.capture());
 
@@ -142,7 +142,7 @@ public class DiagnosticReportControllerTest {
             false,
             tx,
             mraClient,
-            new Bundler(new ConfigurableBaseUrlPageLinks("", "")),
+            new Dstu2Bundler(new ConfigurableBaseUrlPageLinks("", "")),
             null,
             null);
 
@@ -171,7 +171,7 @@ public class DiagnosticReportControllerTest {
             false,
             tx,
             mraClient,
-            new Bundler(new ConfigurableBaseUrlPageLinks("", "")),
+            new Dstu2Bundler(new ConfigurableBaseUrlPageLinks("", "")),
             null,
             null);
 
@@ -278,10 +278,10 @@ public class DiagnosticReportControllerTest {
 
     @SuppressWarnings("unchecked")
     ArgumentCaptor<
-            Bundler.BundleContext<
+            Dstu2Bundler.BundleContext<
                 CdwDiagnosticReport102Root.CdwDiagnosticReports.CdwDiagnosticReport,
                 DiagnosticReport, DiagnosticReport.Entry, DiagnosticReport.Bundle>>
-        captor = ArgumentCaptor.forClass(Bundler.BundleContext.class);
+        captor = ArgumentCaptor.forClass(Dstu2Bundler.BundleContext.class);
 
     verify(bundler).bundle(captor.capture());
     LinkConfig expectedLinkConfig =
@@ -311,7 +311,7 @@ public class DiagnosticReportControllerTest {
                 DiagnosticReport.class);
 
     DiagnosticReport.Bundle bundle = bundleOf(resource);
-    assertThat(controller.validate(bundle)).isEqualTo(Validator.ok());
+    assertThat(controller.validate(bundle)).isEqualTo(Dstu2Validator.ok());
   }
 
   @SneakyThrows

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/encounter/EncounterControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/encounter/EncounterControllerTest.java
@@ -5,11 +5,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
 import gov.va.api.health.dstu2.api.bundle.AbstractBundle.BundleType;
@@ -39,7 +39,7 @@ public class EncounterControllerTest {
   @Mock EncounterController.Transformer tx;
 
   EncounterController controller;
-  @Mock Bundler bundler;
+  @Mock Dstu2Bundler bundler;
 
   @Before
   public void _init() {
@@ -144,7 +144,7 @@ public class EncounterControllerTest {
                 getClass().getResourceAsStream("/cdw/old-encounter-1.01.json"), Encounter.class);
 
     Bundle bundle = bundleOf(resource);
-    assertThat(controller.validate(bundle)).isEqualTo(Validator.ok());
+    assertThat(controller.validate(bundle)).isEqualTo(Dstu2Validator.ok());
   }
 
   @Test(expected = ConstraintViolationException.class)

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/immunization/Dstu2ImmunizationControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/immunization/Dstu2ImmunizationControllerTest.java
@@ -11,8 +11,8 @@ import com.google.common.collect.Multimap;
 import gov.va.api.health.argonaut.api.resources.Immunization;
 import gov.va.api.health.argonaut.api.resources.Immunization.Bundle;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
 import gov.va.api.health.dataquery.service.controller.ConfigurableBaseUrlPageLinks;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dataquery.service.controller.immunization.ImmunizationSamples.Datamart;
@@ -56,7 +56,7 @@ public class Dstu2ImmunizationControllerTest {
 
   Dstu2ImmunizationController controller() {
     return new Dstu2ImmunizationController(
-        new Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
+        new Dstu2Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
         repository,
         WitnessProtection.builder().identityService(ids).build());
   }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/location/DatamartLocationControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/location/DatamartLocationControllerTest.java
@@ -7,8 +7,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
 import gov.va.api.health.dataquery.service.controller.ConfigurableBaseUrlPageLinks;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dstu2.api.bundle.BundleLink.LinkRelation;
@@ -79,7 +79,7 @@ public class DatamartLocationControllerTest {
         true,
         null,
         null,
-        new Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
+        new Dstu2Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
         repository,
         WitnessProtection.builder().identityService(ids).build());
   }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/location/LocationControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/location/LocationControllerTest.java
@@ -5,11 +5,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
 import gov.va.api.health.dstu2.api.bundle.AbstractBundle.BundleType;
@@ -39,7 +39,7 @@ public class LocationControllerTest {
   @Mock LocationController.Transformer tx;
 
   LocationController controller;
-  @Mock Bundler bundler;
+  @Mock Dstu2Bundler bundler;
 
   @Before
   public void _init() {
@@ -146,7 +146,7 @@ public class LocationControllerTest {
                 getClass().getResourceAsStream("/cdw/old-location-1.00.json"), Location.class);
 
     Bundle bundle = bundleOf(resource);
-    assertThat(controller.validate(bundle)).isEqualTo(Validator.ok());
+    assertThat(controller.validate(bundle)).isEqualTo(Dstu2Validator.ok());
   }
 
   @Test(expected = ConstraintViolationException.class)

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medication/Dstu2MedicationControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medication/Dstu2MedicationControllerTest.java
@@ -9,8 +9,8 @@ import static org.mockito.Mockito.when;
 import gov.va.api.health.argonaut.api.resources.Medication;
 import gov.va.api.health.argonaut.api.resources.Medication.Bundle;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
 import gov.va.api.health.dataquery.service.controller.ConfigurableBaseUrlPageLinks;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dataquery.service.controller.medication.MedicationSamples.Datamart;
@@ -52,7 +52,7 @@ public class Dstu2MedicationControllerTest {
 
   Dstu2MedicationController controller() {
     return new Dstu2MedicationController(
-        new Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
+        new Dstu2Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
         repository,
         WitnessProtection.builder().identityService(ids).build());
   }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationdispense/MedicationDispenseControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationdispense/MedicationDispenseControllerTest.java
@@ -5,11 +5,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
 import gov.va.api.health.dstu2.api.bundle.AbstractBundle.BundleType;
@@ -40,7 +40,7 @@ public class MedicationDispenseControllerTest {
 
   MedicationDispenseController controller;
 
-  @Mock Bundler bundler;
+  @Mock Dstu2Bundler bundler;
 
   @Before
   public void _init() {
@@ -173,7 +173,7 @@ public class MedicationDispenseControllerTest {
                 getClass().getResourceAsStream("/cdw/medicationdispense-1.00.json"),
                 MedicationDispense.class);
     Bundle bundle = bundleOf(resource);
-    assertThat(controller.validate(bundle)).isEqualTo(Validator.ok());
+    assertThat(controller.validate(bundle)).isEqualTo(Dstu2Validator.ok());
   }
 
   @Test(expected = ConstraintViolationException.class)

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/Dstu2MedicationOrderControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/Dstu2MedicationOrderControllerTest.java
@@ -10,8 +10,8 @@ import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import gov.va.api.health.argonaut.api.resources.MedicationOrder;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
 import gov.va.api.health.dataquery.service.controller.ConfigurableBaseUrlPageLinks;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dstu2.api.bundle.BundleLink;
@@ -58,7 +58,7 @@ public class Dstu2MedicationOrderControllerTest {
 
   Dstu2MedicationOrderController controller() {
     return new Dstu2MedicationOrderController(
-        new Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
+        new Dstu2Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
         repository,
         WitnessProtection.builder().identityService(ids).build());
   }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationstatement/DatamartMedicationStatementControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationstatement/DatamartMedicationStatementControllerTest.java
@@ -10,8 +10,8 @@ import com.google.common.collect.Multimap;
 import gov.va.api.health.argonaut.api.resources.MedicationStatement;
 import gov.va.api.health.argonaut.api.resources.MedicationStatement.Bundle;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
 import gov.va.api.health.dataquery.service.controller.ConfigurableBaseUrlPageLinks;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dataquery.service.controller.medicationstatement.DatamartMedicationStatementSamples.Datamart;
@@ -64,7 +64,7 @@ public class DatamartMedicationStatementControllerTest {
         true,
         null,
         null,
-        new Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
+        new Dstu2Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
         repository,
         WitnessProtection.builder().identityService(ids).build());
   }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationstatement/MedicationStatementControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationstatement/MedicationStatementControllerTest.java
@@ -7,11 +7,11 @@ import static org.mockito.Mockito.when;
 import gov.va.api.health.argonaut.api.resources.MedicationStatement;
 import gov.va.api.health.argonaut.api.resources.MedicationStatement.Bundle;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
 import gov.va.api.health.dstu2.api.bundle.AbstractBundle.BundleType;
@@ -39,7 +39,7 @@ public class MedicationStatementControllerTest {
   @Mock MedicationStatementController.Transformer tx;
 
   MedicationStatementController controller;
-  @Mock Bundler bundler;
+  @Mock Dstu2Bundler bundler;
 
   @Before
   public void _init() {
@@ -159,7 +159,7 @@ public class MedicationStatementControllerTest {
                 MedicationStatement.class);
 
     Bundle bundle = bundleOf(resource);
-    assertThat(controller.validate(bundle)).isEqualTo(Validator.ok());
+    assertThat(controller.validate(bundle)).isEqualTo(Dstu2Validator.ok());
   }
 
   @Test(expected = ConstraintViolationException.class)

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/observation/DatamartObservationControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/observation/DatamartObservationControllerTest.java
@@ -11,8 +11,8 @@ import com.google.common.collect.Multimap;
 import gov.va.api.health.argonaut.api.resources.Observation;
 import gov.va.api.health.argonaut.api.resources.Observation.Bundle;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
 import gov.va.api.health.dataquery.service.controller.ConfigurableBaseUrlPageLinks;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dataquery.service.controller.observation.DatamartObservation.Category;
@@ -81,7 +81,7 @@ public class DatamartObservationControllerTest {
         true,
         null,
         null,
-        new Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
+        new Dstu2Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
         repository,
         WitnessProtection.builder().identityService(ids).build());
   }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/observation/ObservationControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/observation/ObservationControllerTest.java
@@ -7,11 +7,11 @@ import static org.mockito.Mockito.when;
 import gov.va.api.health.argonaut.api.resources.Observation;
 import gov.va.api.health.argonaut.api.resources.Observation.Bundle;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
 import gov.va.api.health.dstu2.api.bundle.AbstractBundle.BundleType;
@@ -40,7 +40,7 @@ public class ObservationControllerTest {
 
   ObservationController controller;
 
-  @Mock Bundler bundler;
+  @Mock Dstu2Bundler bundler;
 
   @Before
   public void _init() {
@@ -209,7 +209,7 @@ public class ObservationControllerTest {
                 Observation.class);
 
     Bundle bundle = bundleOf(resource);
-    assertThat(controller.validate(bundle)).isEqualTo(Validator.ok());
+    assertThat(controller.validate(bundle)).isEqualTo(Dstu2Validator.ok());
   }
 
   @SneakyThrows

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/organization/OrganizationControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/organization/OrganizationControllerTest.java
@@ -5,11 +5,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
 import gov.va.api.health.dstu2.api.bundle.AbstractBundle.BundleType;
@@ -39,7 +39,7 @@ public class OrganizationControllerTest {
   @Mock OrganizationController.Transformer tx;
 
   OrganizationController controller;
-  @Mock Bundler bundler;
+  @Mock Dstu2Bundler bundler;
 
   @Before
   public void _init() {
@@ -149,7 +149,7 @@ public class OrganizationControllerTest {
                 Organization.class);
 
     Bundle bundle = bundleOf(resource);
-    assertThat(controller.validate(bundle)).isEqualTo(Validator.ok());
+    assertThat(controller.validate(bundle)).isEqualTo(Dstu2Validator.ok());
   }
 
   @Test(expected = ConstraintViolationException.class)

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/DatamartPatientTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/DatamartPatientTest.java
@@ -1,7 +1,7 @@
 package gov.va.api.health.dataquery.service.controller.patient;
 
 import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
-import static gov.va.api.health.dataquery.service.controller.Transformers.parseInstant;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.parseInstant;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -11,8 +11,8 @@ import com.google.common.collect.Iterables;
 import gov.va.api.health.argonaut.api.resources.Patient;
 import gov.va.api.health.argonaut.api.resources.Patient.Gender;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
 import gov.va.api.health.dataquery.service.controller.ConfigurableBaseUrlPageLinks;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dstu2.api.datatypes.Address;
 import gov.va.api.health.dstu2.api.datatypes.CodeableConcept;
@@ -144,7 +144,7 @@ public final class DatamartPatientTest {
         true,
         null,
         null,
-        new Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
+        new Dstu2Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
         repository,
         WitnessProtection.builder().identityService(mock(IdentityService.class)).build());
   }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/PatientControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/PatientControllerTest.java
@@ -7,11 +7,11 @@ import static org.mockito.Mockito.when;
 import gov.va.api.health.argonaut.api.resources.Patient;
 import gov.va.api.health.argonaut.api.resources.Patient.Bundle;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
 import gov.va.api.health.dstu2.api.bundle.AbstractBundle.BundleType;
@@ -35,7 +35,7 @@ import org.springframework.util.MultiValueMap;
 public class PatientControllerTest {
   @Mock MrAndersonClient client;
   @Mock PatientController.Transformer tx;
-  @Mock Bundler bundler;
+  @Mock Dstu2Bundler bundler;
 
   PatientController controller;
 
@@ -220,7 +220,7 @@ public class PatientControllerTest {
             .readValue(getClass().getResourceAsStream("/cdw/old-patient-1.03.json"), Patient.class);
 
     Bundle bundle = bundleOf(resource);
-    assertThat(controller.validate(bundle)).isEqualTo(Validator.ok());
+    assertThat(controller.validate(bundle)).isEqualTo(Dstu2Validator.ok());
   }
 
   @Test(expected = ConstraintViolationException.class)

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/PractitionerControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/PractitionerControllerTest.java
@@ -5,11 +5,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
 import gov.va.api.health.dstu2.api.bundle.AbstractBundle.BundleType;
@@ -40,7 +40,7 @@ public class PractitionerControllerTest {
   @Mock PractitionerController.Transformer tx;
 
   PractitionerController controller;
-  @Mock Bundler bundler;
+  @Mock Dstu2Bundler bundler;
 
   @Before
   public void _init() {
@@ -147,7 +147,7 @@ public class PractitionerControllerTest {
                 Practitioner.class);
 
     Bundle bundle = bundleOf(resource);
-    assertThat(controller.validate(bundle)).isEqualTo(Validator.ok());
+    assertThat(controller.validate(bundle)).isEqualTo(Dstu2Validator.ok());
   }
 
   @Test(expected = ConstraintViolationException.class)

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/procedure/DatamartProcedureControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/procedure/DatamartProcedureControllerTest.java
@@ -11,8 +11,8 @@ import com.google.common.collect.Multimap;
 import gov.va.api.health.argonaut.api.resources.Procedure;
 import gov.va.api.health.argonaut.api.resources.Procedure.Bundle;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
 import gov.va.api.health.dataquery.service.controller.ConfigurableBaseUrlPageLinks;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dataquery.service.controller.procedure.DatamartProcedureSamples.Datamart;
@@ -72,7 +72,7 @@ public class DatamartProcedureControllerTest {
         "Superman",
         null,
         null,
-        new Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
+        new Dstu2Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool")),
         repository,
         WitnessProtection.builder().identityService(ids).build());
   }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/procedure/ProcedureControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/procedure/ProcedureControllerTest.java
@@ -9,11 +9,11 @@ import static org.mockito.Mockito.when;
 import gov.va.api.health.argonaut.api.resources.Procedure;
 import gov.va.api.health.argonaut.api.resources.Procedure.Bundle;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.Bundler;
-import gov.va.api.health.dataquery.service.controller.Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
+import gov.va.api.health.dataquery.service.controller.Dstu2Bundler.BundleContext;
+import gov.va.api.health.dataquery.service.controller.Dstu2Validator;
 import gov.va.api.health.dataquery.service.controller.PageLinks.LinkConfig;
 import gov.va.api.health.dataquery.service.controller.Parameters;
-import gov.va.api.health.dataquery.service.controller.Validator;
 import gov.va.api.health.dataquery.service.mranderson.client.MrAndersonClient;
 import gov.va.api.health.dataquery.service.mranderson.client.Query;
 import gov.va.api.health.dstu2.api.bundle.AbstractBundle.BundleType;
@@ -45,7 +45,7 @@ public class ProcedureControllerTest {
 
   @Mock ProcedureController.Transformer tx;
 
-  @Mock Bundler bundler;
+  @Mock Dstu2Bundler bundler;
 
   ProcedureController controller;
 
@@ -328,7 +328,7 @@ public class ProcedureControllerTest {
             .readValue(
                 getClass().getResourceAsStream("/cdw/old-procedure-1.01.json"), Procedure.class);
     Procedure.Bundle bundle = bundleOf(resource);
-    assertThat(controller.validate(bundle)).isEqualTo(Validator.ok());
+    assertThat(controller.validate(bundle)).isEqualTo(Dstu2Validator.ok());
   }
 
   @SneakyThrows

--- a/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DDiagnosticReportTransformer.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DDiagnosticReportTransformer.java
@@ -3,7 +3,7 @@ package gov.va.api.health.dataquery.tools.minimart.transformers;
 import static org.codehaus.groovy.runtime.InvokerHelper.asList;
 
 import gov.va.api.health.argonaut.api.resources.DiagnosticReport;
-import gov.va.api.health.dataquery.service.controller.Transformers;
+import gov.va.api.health.dataquery.service.controller.Dstu2Transformers;
 import gov.va.api.health.dataquery.service.controller.diagnosticreport.DatamartDiagnosticReports;
 import gov.va.api.health.dataquery.tools.minimart.FhirToDatamartUtils;
 import gov.va.api.health.dstu2.api.elements.Reference;
@@ -30,7 +30,7 @@ public class F2DDiagnosticReportTransformer {
         diagnosticReport.performer() != null && diagnosticReport.performer().reference() != null
             ? fauxIds.unmaskByReference(diagnosticReport.performer().reference())
             : null;
-    return Transformers.emptyToNull(
+    return Dstu2Transformers.emptyToNull(
         asList(
             DatamartDiagnosticReports.DiagnosticReport.builder()
                 .identifier(fauxIds.unmask("DiagnosticReport", diagnosticReport.id()))

--- a/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DObservationTransformer.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DObservationTransformer.java
@@ -1,6 +1,6 @@
 package gov.va.api.health.dataquery.tools.minimart.transformers;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.isBlank;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.isBlank;
 
 import gov.va.api.health.argonaut.api.resources.Observation;
 import gov.va.api.health.dataquery.service.controller.EnumSearcher;

--- a/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DPatientTransformer.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DPatientTransformer.java
@@ -1,6 +1,6 @@
 package gov.va.api.health.dataquery.tools.minimart.transformers;
 
-import static gov.va.api.health.dataquery.service.controller.Transformers.parseInstant;
+import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.parseInstant;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import gov.va.api.health.argonaut.api.resources.Patient;


### PR DESCRIPTION
https://vasdvp.atlassian.net/browse/SSS-94

To avoid a giant monster PR for supporting Stu3 location, this PR adds the `Dstu2` prefix to the `Bundler`, `Transformers`, and `Validator` classes.

`Stu3` implementations coming soon...

![image](https://user-images.githubusercontent.com/46896876/70452052-77ffc200-1a74-11ea-970f-2da7ae0db1c5.png)
