### PR TITLE
Shank 269 observation query perf

### DIFF
--- a/data-query-ids-mapping/pom.xml
+++ b/data-query-ids-mapping/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>api-starter</artifactId>
-    <version>4.0.6</version>
+    <version>5.0.0-SNAPSHOT</version>
     <relativePath/>
   </parent>
   <artifactId>data-query-ids-mapping</artifactId>

--- a/data-query-tests/mitre-minimart-maker.sh
+++ b/data-query-tests/mitre-minimart-maker.sh
@@ -45,7 +45,7 @@ startMinimartApp() {
   local pathSeparator=':'
   [ "$(uname)" != "Darwin" ] && [ "$(uname)" != "Linux" ] && echo "Add support for your operating system" && exit 1
   echo "Using local H2 database for $app..."
-  options+=" -cp $(readlink -f $jar)${pathSeparator}$(readlink -f ~/.m2/repository/com/h2database/h2/1.4.197/h2-1.4.197.jar)"
+  options+=" -cp $(readlink -f $jar)${pathSeparator}$(readlink -f ~/.m2/repository/com/h2database/h2/1.4.200/h2-1.4.200.jar)"
   if [ "$app" == 'data-query' ]
   then
     # application-dev.properties
@@ -115,7 +115,7 @@ transformFhirToDatamart() {
 }
 
 openDatabase() {
-  java -jar ~/.m2/repository/com/h2database/h2/1.4.197/h2-1.4.197.jar -url jdbc:h2:$1 -user sa -password sa
+  java -jar ~/.m2/repository/com/h2database/h2/1.4.200/h2-1.4.200.jar -url jdbc:h2:$1 -user sa -password sa
 }
 
 usage() {

--- a/data-query-tests/open-local-mitre-db.sh
+++ b/data-query-tests/open-local-mitre-db.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-java -jar ~/.m2/repository/com/h2database/h2/1.4.197/h2-1.4.197.jar -url jdbc:h2:./src/test/resources/mitre -user sa -password sa
+java -jar ~/.m2/repository/com/h2database/h2/1.4.200/h2-1.4.200.jar -url jdbc:h2:./src/test/resources/mitre -user sa -password sa

--- a/data-query-tests/pom.xml
+++ b/data-query-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>test-starter</artifactId>
-    <version>4.0.6</version>
+    <version>5.0.0-SNAPSHOT</version>
     <relativePath/>
   </parent>
   <artifactId>data-query-tests</artifactId>

--- a/data-query-tests/src/main/java/gov/va/api/health/dataquery/tests/IdRegistrar.java
+++ b/data-query-tests/src/main/java/gov/va/api/health/dataquery/tests/IdRegistrar.java
@@ -25,8 +25,7 @@ public final class IdRegistrar {
   TestIds registeredIds = registerCdwIds();
 
   private String findUuid(List<Registration> registrations, ResourceIdentity resource) {
-    return registrations
-        .stream()
+    return registrations.stream()
         .filter(r -> r.resourceIdentities().contains(resource))
         .findFirst()
         .orElseThrow(() -> new AssertionError("Failed to register: " + resource))

--- a/data-query-tests/src/main/java/gov/va/api/health/dataquery/tests/crawler/ResourceDiscovery.java
+++ b/data-query-tests/src/main/java/gov/va/api/health/dataquery/tests/crawler/ResourceDiscovery.java
@@ -94,9 +94,7 @@ public class ResourceDiscovery {
     if (conformanceStatement == null || conformanceStatement.rest() == null) {
       return emptyList();
     }
-    return conformanceStatement
-        .rest()
-        .stream()
+    return conformanceStatement.rest().stream()
         .flatMap(r -> r.resource().stream())
         .collect(Collectors.toList());
   }
@@ -116,10 +114,7 @@ public class ResourceDiscovery {
     }
     List<String> patientQueries = new ArrayList<>();
     boolean isReadable =
-        patientMetadata
-            .get()
-            .interaction()
-            .stream()
+        patientMetadata.get().interaction().stream()
             .anyMatch(p -> ResourceInteractionCode.read.equals(p.code()));
     if (isReadable) {
       patientQueries.add(url + "Patient/" + patientId);
@@ -138,8 +133,7 @@ public class ResourceDiscovery {
    * https://awesome.com/api/Procedure?patient=12345.
    */
   List<String> patientSearchableResourceQueries(@NonNull List<RestResource> restResources) {
-    return restResources
-        .stream()
+    return restResources.stream()
         .filter(this::isSearchableByPatient)
         .map(p -> url + p.type() + "?patient=" + patientId)
         .collect(Collectors.toList());

--- a/data-query-tests/src/main/java/gov/va/api/health/dataquery/tests/crawler/SummarizingResultCollector.java
+++ b/data-query-tests/src/main/java/gov/va/api/health/dataquery/tests/crawler/SummarizingResultCollector.java
@@ -120,8 +120,7 @@ public class SummarizingResultCollector implements ResultCollector {
   private Map<String, SummaryStats> summarize(Predicate<Result> include) {
     Map<String, SummaryStats> statsByResource = new HashMap<>();
 
-    summaries
-        .stream()
+    summaries.stream()
         .filter(include)
         .forEach(
             result -> {

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/crawler/ReferenceInterceptorTest.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/crawler/ReferenceInterceptorTest.java
@@ -67,9 +67,8 @@ public class ReferenceInterceptorTest {
   @NoArgsConstructor(access = AccessLevel.PRIVATE)
   @AllArgsConstructor
   @JsonAutoDetect(
-    fieldVisibility = JsonAutoDetect.Visibility.ANY,
-    isGetterVisibility = Visibility.NONE
-  )
+      fieldVisibility = JsonAutoDetect.Visibility.ANY,
+      isGetterVisibility = Visibility.NONE)
   public static class FugaziReferencemajig {
     Reference ref;
     Reference nope;

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/PatientBulkFhirIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/PatientBulkFhirIT.java
@@ -30,8 +30,12 @@ public class PatientBulkFhirIT {
 
   @Test
   @Category(
-    value = {Local.class, LabDataQueryPatient.class, ProdDataQueryPatient.class, InternalApi.class}
-  )
+      value = {
+        Local.class,
+        LabDataQueryPatient.class,
+        ProdDataQueryPatient.class,
+        InternalApi.class
+      })
   public void bulkFhirPatientSearch() {
     log.info("Verify Patient Bulk Search internal/bulk/Patient?page=x&_count=y");
     ExpectedResponse responseAll =

--- a/data-query/pom.xml
+++ b/data-query/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>service-starter</artifactId>
-    <version>4.0.6</version>
+    <version>5.0.0-SNAPSHOT</version>
     <relativePath/>
   </parent>
   <artifactId>data-query</artifactId>

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/api/DataQueryService.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/api/DataQueryService.java
@@ -25,87 +25,81 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import javax.ws.rs.Path;
 
 @OpenAPIDefinition(
-  security =
-      @SecurityRequirement(
-        name = "OauthFlow",
-        scopes = {
-          "patient/AllergyIntolerance.read",
-          "patient/Condition.read",
-          "patient/DiagnosticReport.read",
-          "patient/Immunization.read",
-          "patient/Medication.read",
-          "patient/MedicationOrder.read",
-          "patient/MedicationStatement.read",
-          "patient/Observation.read",
-          "patient/Patient.read",
-          "patient/Procedure.read",
-          "offline_access",
-          "launch/patient"
-        }
-      ),
-  info =
-      @Info(
-        title = "Argonaut Data Query",
-        version = "v1",
-        description =
-            " This service is compliant with the FHIR Argonaut Data Query Implementation"
-                + " Guide. This service does not provide or replace the consultation,"
-                + " guidance, or care of a health care professional or other qualified provider."
-                + " This service provides a supplement for informational and educational"
-                + " purposes only. Health care professionals and other qualified providers"
-                + " should continue to consult authoritative records when making decisions."
-      ),
-  servers = {
-    @Server(
-      url = "https://dev-api.va.gov/services/fhir/v0/argonaut/data-query/",
-      description = "Development server"
-    )
-  },
-  externalDocs =
-      @ExternalDocumentation(
-        description = "Argonaut Data Query Implementation Guide",
-        url = "http://www.fhir.org/guides/argonaut/r2/index.html"
-      )
-)
+    security =
+        @SecurityRequirement(
+            name = "OauthFlow",
+            scopes = {
+              "patient/AllergyIntolerance.read",
+              "patient/Condition.read",
+              "patient/DiagnosticReport.read",
+              "patient/Immunization.read",
+              "patient/Medication.read",
+              "patient/MedicationOrder.read",
+              "patient/MedicationStatement.read",
+              "patient/Observation.read",
+              "patient/Patient.read",
+              "patient/Procedure.read",
+              "offline_access",
+              "launch/patient"
+            }),
+    info =
+        @Info(
+            title = "Argonaut Data Query",
+            version = "v1",
+            description =
+                " This service is compliant with the FHIR Argonaut Data Query Implementation"
+                    + " Guide. This service does not provide or replace the consultation, guidance,"
+                    + " or care of a health care professional or other qualified provider."
+                    + " This service provides a supplement for informational and educational"
+                    + " purposes only. Health care professionals and other qualified providers"
+                    + " should continue to consult authoritative records when making decisions."),
+    servers = {
+      @Server(
+          url = "https://dev-api.va.gov/services/fhir/v0/argonaut/data-query/",
+          description = "Development server")
+    },
+    externalDocs =
+        @ExternalDocumentation(
+            description = "Argonaut Data Query Implementation Guide",
+            url = "http://www.fhir.org/guides/argonaut/r2/index.html"))
 @SecurityScheme(
-  name = "OauthFlow",
-  type = SecuritySchemeType.OAUTH2,
-  in = SecuritySchemeIn.HEADER,
-  flows =
-      @OAuthFlows(
-        implicit =
-            @OAuthFlow(
-              authorizationUrl = "https://dev-api.va.gov/oauth2/authorization",
-              tokenUrl = "https://dev-api.va.gov/services/fhir/v0/dstu2/token",
-              scopes = {
-                @OAuthScope(
-                  name = "patient/AllergyIntolerance.read",
-                  description = "read allergy intolerances"
-                ),
-                @OAuthScope(name = "patient/Condition.read", description = "read conditions"),
-                @OAuthScope(
-                  name = "patient/DiagnosticReport.read",
-                  description = "read diagnostic reports"
-                ),
-                @OAuthScope(name = "patient/Immunization.read", description = "read immunizations"),
-                @OAuthScope(name = "patient/Medication.read", description = "read medications"),
-                @OAuthScope(
-                  name = "patient/MedicationOrder.read",
-                  description = "read medication orders"
-                ),
-                @OAuthScope(
-                  name = "patient/MedicationStatement.read",
-                  description = "read medication statements"
-                ),
-                @OAuthScope(name = "patient/Observation.read", description = "read observations"),
-                @OAuthScope(name = "patient/Patient.read", description = "read patient"),
-                @OAuthScope(name = "patient/Procedure.read", description = "read procedures"),
-                @OAuthScope(name = "offline_access", description = "offline access"),
-                @OAuthScope(name = "launch/patient", description = "patient launch"),
-              }
-            )
-      )
-)
+    name = "OauthFlow",
+    type = SecuritySchemeType.OAUTH2,
+    in = SecuritySchemeIn.HEADER,
+    flows =
+        @OAuthFlows(
+            implicit =
+                @OAuthFlow(
+                    authorizationUrl = "https://dev-api.va.gov/oauth2/authorization",
+                    tokenUrl = "https://dev-api.va.gov/services/fhir/v0/dstu2/token",
+                    scopes = {
+                      @OAuthScope(
+                          name = "patient/AllergyIntolerance.read",
+                          description = "read allergy intolerances"),
+                      @OAuthScope(name = "patient/Condition.read", description = "read conditions"),
+                      @OAuthScope(
+                          name = "patient/DiagnosticReport.read",
+                          description = "read diagnostic reports"),
+                      @OAuthScope(
+                          name = "patient/Immunization.read",
+                          description = "read immunizations"),
+                      @OAuthScope(
+                          name = "patient/Medication.read",
+                          description = "read medications"),
+                      @OAuthScope(
+                          name = "patient/MedicationOrder.read",
+                          description = "read medication orders"),
+                      @OAuthScope(
+                          name = "patient/MedicationStatement.read",
+                          description = "read medication statements"),
+                      @OAuthScope(
+                          name = "patient/Observation.read",
+                          description = "read observations"),
+                      @OAuthScope(name = "patient/Patient.read", description = "read patient"),
+                      @OAuthScope(name = "patient/Procedure.read", description = "read procedures"),
+                      @OAuthScope(name = "offline_access", description = "offline access"),
+                      @OAuthScope(name = "launch/patient", description = "patient launch"),
+                    })))
 @Path("/")
 public interface DataQueryService
     extends AllergyIntoleranceApi,

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/config/FhirMediaTypesConfig.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/config/FhirMediaTypesConfig.java
@@ -45,8 +45,7 @@ public class FhirMediaTypesConfig implements WebMvcConfigurer {
      * Augment the standard Jackson mapper to also support application/json+fhir.
      */
     Optional<MappingJackson2HttpMessageConverter> jackson =
-        converters
-            .stream()
+        converters.stream()
             .filter(c -> c instanceof MappingJackson2HttpMessageConverter)
             .map(c -> (MappingJackson2HttpMessageConverter) c)
             .findFirst();

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/ConfigurableBaseUrlPageLinks.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/ConfigurableBaseUrlPageLinks.java
@@ -132,9 +132,7 @@ public class ConfigurableBaseUrlPageLinks implements PageLinks {
       StringBuilder msg = new StringBuilder(baseUrl).append('/').append(basePath).append('/');
       msg.append(config.path()).append('?');
       String params =
-          mutableParams
-              .entrySet()
-              .stream()
+          mutableParams.entrySet().stream()
               .sorted(Comparator.comparing(Entry::getKey))
               .flatMap(this::toKeyValueString)
               .collect(Collectors.joining("&"));

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/DataQueryHomeController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/DataQueryHomeController.java
@@ -39,9 +39,8 @@ public class DataQueryHomeController {
    * redirect.
    */
   @GetMapping(
-    value = {"dstu2/", "dstu2/openapi.json"},
-    produces = "application/json"
-  )
+      value = {"dstu2/", "dstu2/openapi.json"},
+      produces = "application/json")
   @ResponseBody
   public Object openapiJson() throws IOException {
     return DataQueryHomeController.MAPPER.readValue(openapiContent(), Object.class);
@@ -49,9 +48,8 @@ public class DataQueryHomeController {
 
   /** Provide access to the OpenAPI yaml via RESTful interface. */
   @GetMapping(
-    value = {"/dstu2/openapi.yaml"},
-    produces = "application/vnd.oai.openapi"
-  )
+      value = {"/dstu2/openapi.yaml"},
+      produces = "application/vnd.oai.openapi")
   @ResponseBody
   public String openapiYaml() throws IOException {
     return openapiContent();

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/Dstu2Bundler.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/Dstu2Bundler.java
@@ -35,9 +35,7 @@ public class Dstu2Bundler {
     bundle.total(context.linkConfig().totalRecords());
     bundle.link(links.dstu2Links(context.linkConfig()));
     bundle.entry(
-        context
-            .xmlItems()
-            .stream()
+        context.xmlItems().stream()
             .map(context.transformer())
             .map(
                 t -> {

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/IdentityParameterReplacer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/IdentityParameterReplacer.java
@@ -32,8 +32,7 @@ final class IdentityParameterReplacer {
     // @Singular Map<String, String> emits a compiler warning from the Lombok code (?)
     // List of pairs is a workaround.
     this.aliases =
-        aliases
-            .stream()
+        aliases.stream()
             .collect(Collectors.toMap(alias -> alias.getKey(), alias -> alias.getValue()));
   }
 
@@ -51,9 +50,7 @@ final class IdentityParameterReplacer {
   }
 
   private String lookupCdwId(String uuid) {
-    return identityService
-        .lookup(uuid)
-        .stream()
+    return identityService.lookup(uuid).stream()
         .filter(IdentityParameterReplacer::isCdw)
         .map(ResourceIdentity::identifier)
         .findFirst()

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/ResourceExceptions.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/ResourceExceptions.java
@@ -29,9 +29,7 @@ public final class ResourceExceptions {
     }
     StringBuilder msg = new StringBuilder();
     String params =
-        parameters
-            .entrySet()
-            .stream()
+        parameters.entrySet().stream()
             .sorted(Comparator.comparing(Entry::getKey))
             .flatMap(ResourceExceptions::toKeyValueString)
             .collect(Collectors.joining("&"));

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/Stu3Bundler.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/Stu3Bundler.java
@@ -34,8 +34,7 @@ public class Stu3Bundler {
     bundle.total(linkConfig.totalRecords());
     bundle.link(links.stu3Links(linkConfig));
     bundle.entry(
-        resources
-            .stream()
+        resources.stream()
             .map(
                 t -> {
                   E entry = newEntry.get();

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/WebExceptionHandler.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/WebExceptionHandler.java
@@ -143,8 +143,7 @@ public class WebExceptionHandler {
   public OperationOutcome handleValidationException(
       ConstraintViolationException e, HttpServletRequest request) {
     List<String> problems =
-        e.getConstraintViolations()
-            .stream()
+        e.getConstraintViolations().stream()
             .map(v -> v.getPropertyPath() + " " + v.getMessage())
             .collect(Collectors.toList());
     return responseFor("structure", e, request, problems);

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/WitnessProtection.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/WitnessProtection.java
@@ -53,8 +53,7 @@ public class WitnessProtection {
   public <T extends HasReplaceableId> IdentityMapping register(
       Collection<T> resources, Function<T, Stream<DatamartReference>> referencesOf) {
     Set<ResourceIdentity> ids =
-        resources
-            .stream()
+        resources.stream()
             .flatMap(embellish(referencesOf))
             .filter(Objects::nonNull)
             .filter(DatamartReference::hasTypeAndReference)
@@ -64,8 +63,7 @@ public class WitnessProtection {
             .collect(Collectors.toSet());
     IdentityMapping identityMapping = registerAndMap(ids);
 
-    resources
-        .stream()
+    resources.stream()
         .forEach(r -> identityMapping.publicIdOf(r.asReference()).ifPresent(r::cdwId));
 
     return identityMapping;
@@ -136,8 +134,7 @@ public class WitnessProtection {
       Collection<T> resources,
       Function<T, Stream<DatamartReference>> referencesOf,
       IdentityMapping mapping) {
-    resources
-        .stream()
+    resources.stream()
         .flatMap(referencesOf)
         .filter(Objects::nonNull)
         .forEach(

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/Dstu2AllergyIntoleranceController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/Dstu2AllergyIntoleranceController.java
@@ -42,9 +42,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequestMapping(
-  value = {"/dstu2/AllergyIntolerance"},
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = {"/dstu2/AllergyIntolerance"},
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 public class Dstu2AllergyIntoleranceController {
 
   private Dstu2Bundler bundler;
@@ -96,9 +95,8 @@ public class Dstu2AllergyIntoleranceController {
 
   /** Return the raw Datamart document for the given identifier. */
   @GetMapping(
-    value = "/{publicId}",
-    headers = {"raw=true"}
-  )
+      value = "/{publicId}",
+      headers = {"raw=true"})
   public String readRaw(@PathVariable("publicId") String publicId, HttpServletResponse response) {
     AllergyIntoleranceEntity entity = findById(publicId);
     IncludesIcnMajig.addHeader(response, entity.icn());
@@ -168,14 +166,12 @@ public class Dstu2AllergyIntoleranceController {
       return bundle(publicParameters, emptyList(), (int) entitiesPage.getTotalElements());
     }
     List<DatamartAllergyIntolerance> datamarts =
-        entitiesPage
-            .stream()
+        entitiesPage.stream()
             .map(e -> e.asDatamartAllergyIntolerance())
             .collect(Collectors.toList());
     replaceReferences(datamarts);
     List<AllergyIntolerance> fhir =
-        datamarts
-            .stream()
+        datamarts.stream()
             .map(dm -> Dstu2AllergyIntoleranceTransformer.builder().datamart(dm).build().toFhir())
             .collect(Collectors.toList());
     return bundle(publicParameters, fhir, (int) entitiesPage.getTotalElements());
@@ -183,9 +179,8 @@ public class Dstu2AllergyIntoleranceController {
 
   /** Hey, this is a validate endpoint. It validates. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody AllergyIntolerance.Bundle bundle) {
     return Dstu2Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/Dstu2AllergyIntoleranceTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/Dstu2AllergyIntoleranceTransformer.java
@@ -46,14 +46,12 @@ public final class Dstu2AllergyIntoleranceTransformer {
       return null;
     }
     List<Coding> codings =
-        manifestations
-            .stream()
+        manifestations.stream()
             .map(m -> asCoding(m))
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
     return emptyToNull(
-        codings
-            .stream()
+        codings.stream()
             .map(coding -> CodeableConcept.builder().coding(asList(coding)).build())
             .collect(Collectors.toList()));
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/appointment/Dstu2AppointmentController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/appointment/Dstu2AppointmentController.java
@@ -26,9 +26,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequestMapping(
-  value = {"/dstu2/Appointment"},
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = {"/dstu2/Appointment"},
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
 public class Dstu2AppointmentController {
 
@@ -67,9 +66,8 @@ public class Dstu2AppointmentController {
 
   /** Hey, this is a validate endpoint. It validates. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody Appointment.Bundle bundle) {
     return Dstu2Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/appointment/Dstu2AppointmentIncludesIcnMajig.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/appointment/Dstu2AppointmentIncludesIcnMajig.java
@@ -28,8 +28,7 @@ public class Dstu2AppointmentIncludesIcnMajig implements ResponseBodyAdvice<Obje
                   Stream.ofNullable(
                       body.participant() == null || body.participant().isEmpty()
                           ? null
-                          : body.participant()
-                              .stream()
+                          : body.participant().stream()
                               .map(p -> p.actor())
                               .filter(r -> r.reference().contains("Patient"))
                               .map(i -> Dstu2Transformers.asReferenceId(i))

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/condition/Dstu2ConditionController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/condition/Dstu2ConditionController.java
@@ -46,9 +46,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequestMapping(
-  value = {"/dstu2/Condition"},
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = {"/dstu2/Condition"},
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 public class Dstu2ConditionController {
 
   private Dstu2Bundler bundler;
@@ -121,9 +120,8 @@ public class Dstu2ConditionController {
 
   /** Read by id. */
   @GetMapping(
-    value = {"/{publicId}"},
-    headers = {"raw=true"}
-  )
+      value = {"/{publicId}"},
+      headers = {"raw=true"})
   public String readRaw(@PathVariable("publicId") String publicId, HttpServletResponse response) {
     ConditionEntity entity = findById(publicId);
     IncludesIcnMajig.addHeader(response, entity.icn());
@@ -193,8 +191,7 @@ public class Dstu2ConditionController {
         entitiesPage.stream().map(e -> e.asDatamartCondition()).collect(Collectors.toList());
     replaceReferences(datamarts);
     List<Condition> fhir =
-        datamarts
-            .stream()
+        datamarts.stream()
             .map(dm -> Dstu2ConditionTransformer.builder().datamart(dm).build().toFhir())
             .collect(Collectors.toList());
     return bundle(parameters, fhir, (int) entitiesPage.getTotalElements());
@@ -245,9 +242,8 @@ public class Dstu2ConditionController {
 
   /** Hey, this is a validate endpoint. It validates. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody Condition.Bundle bundle) {
     return Dstu2Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/conformance/MetadataController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/conformance/MetadataController.java
@@ -40,9 +40,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping(
-  value = {"/dstu2/metadata"},
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = {"/dstu2/metadata"},
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
 class MetadataController {
   private static final String ALLERGYINTOLERANCE_HTML =
@@ -384,8 +383,7 @@ class MetadataController {
       if (search.isEmpty()) {
         return null;
       }
-      return search
-          .stream()
+      return search.stream()
           .map(s -> Conformance.SearchParam.builder().name(s.param()).type(s.type()).build())
           .collect(Collectors.toList());
     }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/Dstu2DiagnosticReportController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/Dstu2DiagnosticReportController.java
@@ -64,9 +64,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @SuppressWarnings("WeakerAccess")
 @RequestMapping(
-  value = {"/dstu2/DiagnosticReport"},
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = {"/dstu2/DiagnosticReport"},
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 public class Dstu2DiagnosticReportController {
   private Dstu2Bundler bundler;
 
@@ -106,8 +105,7 @@ public class Dstu2DiagnosticReportController {
     }
     List<DateTimeParameters> parameters =
         dateParameters.stream().map(DateTimeParameters::new).collect(Collectors.toList());
-    return datamartReports
-        .stream()
+    return datamartReports.stream()
         .filter(r -> parameters.stream().allMatch(p -> dateParameterIsSatisfied(r, p)))
         .collect(Collectors.toList());
   }
@@ -152,9 +150,7 @@ public class Dstu2DiagnosticReportController {
     DatamartDiagnosticReports payload =
         Iterables.getOnlyElement(entities).asDatamartDiagnosticReports();
     Optional<DatamartDiagnosticReports.DiagnosticReport> maybeReport =
-        payload
-            .reports()
-            .stream()
+        payload.reports().stream()
             .filter(r -> StringUtils.equals(r.identifier(), cdwReportId))
             .findFirst();
     if (!maybeReport.isPresent()) {
@@ -181,9 +177,8 @@ public class Dstu2DiagnosticReportController {
 
   /** Return the raw Datamart document for the given identifier. */
   @GetMapping(
-    value = {"/{publicId}"},
-    headers = {"raw=true"}
-  )
+      value = {"/{publicId}"},
+      headers = {"raw=true"})
   public DatamartDiagnosticReports.DiagnosticReport readRaw(
       @PathVariable("publicId") String publicId, HttpServletResponse response) {
     var pair = pairPayload(publicId);
@@ -194,8 +189,7 @@ public class Dstu2DiagnosticReportController {
   private void replaceCdwIdsWithPublicIds(
       List<DatamartDiagnosticReports.DiagnosticReport> reports) {
     Set<ResourceIdentity> ids =
-        reports
-            .stream()
+        reports.stream()
             .flatMap(
                 report ->
                     Stream.concat(
@@ -212,9 +206,7 @@ public class Dstu2DiagnosticReportController {
                                     .identifier(report.accessionInstitutionSid())
                                     .build()
                                 : null),
-                        report
-                            .results()
-                            .stream()
+                        report.results().stream()
                             .flatMap(
                                 r ->
                                     Stream.of(
@@ -295,8 +287,7 @@ public class Dstu2DiagnosticReportController {
     List<DatamartDiagnosticReports.DiagnosticReport> paged = filtered.subList(fromIndex, toIndex);
     replaceCdwIdsWithPublicIds(paged);
     List<DiagnosticReport> fhir =
-        paged
-            .stream()
+        paged.stream()
             .map(
                 dm ->
                     Dstu2DiagnosticReportTransformer.builder()
@@ -385,9 +376,8 @@ public class Dstu2DiagnosticReportController {
 
   /** Search by patient. */
   @GetMapping(
-    value = "/raw",
-    params = {"patient"}
-  )
+      value = "/raw",
+      params = {"patient"})
   public String searchByPatientRaw(
       @RequestParam("patient") String patient, HttpServletResponse response) {
     MultiValueMap<String, String> publicParameters =
@@ -405,9 +395,8 @@ public class Dstu2DiagnosticReportController {
 
   /** Validate Endpoint. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody DiagnosticReport.Bundle bundle) {
     return Dstu2Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/encounter/Dstu2EncounterController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/encounter/Dstu2EncounterController.java
@@ -27,9 +27,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequestMapping(
-  value = {"/dstu2/Encounter"},
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = {"/dstu2/Encounter"},
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
 public class Dstu2EncounterController {
 
@@ -62,9 +61,8 @@ public class Dstu2EncounterController {
 
   /** Hey, this is a validate endpoint. It validates. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody Encounter.Bundle bundle) {
     return Dstu2Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/Dstu2ImmunizationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/Dstu2ImmunizationController.java
@@ -43,9 +43,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequestMapping(
-  value = {"/dstu2/Immunization"},
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = {"/dstu2/Immunization"},
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 @Slf4j
 public class Dstu2ImmunizationController {
 
@@ -116,9 +115,8 @@ public class Dstu2ImmunizationController {
 
   /** Read by id. */
   @GetMapping(
-    value = {"/{publicId}"},
-    headers = {"raw=true"}
-  )
+      value = {"/{publicId}"},
+      headers = {"raw=true"})
   public String readRaw(@PathVariable("publicId") String publicId, HttpServletResponse response) {
     ImmunizationEntity entity = findById(publicId);
     IncludesIcnMajig.addHeader(response, entity.icn());
@@ -186,9 +184,8 @@ public class Dstu2ImmunizationController {
 
   /** Hey, this is a validate endpoint. It validates. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody Immunization.Bundle bundle) {
     return Dstu2Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/location/Dstu2LocationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/location/Dstu2LocationController.java
@@ -36,9 +36,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @SuppressWarnings("WeakerAccess")
 @RequestMapping(
-  value = "/dstu2/Location",
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = "/dstu2/Location",
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 public class Dstu2LocationController {
   private Dstu2Bundler bundler;
 
@@ -87,9 +86,8 @@ public class Dstu2LocationController {
 
   /** Read raw. */
   @GetMapping(
-    value = {"/{publicId}"},
-    headers = {"raw=true"}
-  )
+      value = {"/{publicId}"},
+      headers = {"raw=true"})
   public String readRaw(@PathVariable("publicId") String publicId, HttpServletResponse response) {
     IncludesIcnMajig.addHeaderForNoPatients(response);
     return entityById(publicId).payload();
@@ -123,9 +121,8 @@ public class Dstu2LocationController {
 
   /** Hey, this is a validate endpoint. It validates. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody Location.Bundle bundle) {
     return Dstu2Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/location/Stu3LocationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/location/Stu3LocationController.java
@@ -42,9 +42,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequestMapping(
-  value = {"/stu3/Location"},
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = {"/stu3/Location"},
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 @SuppressWarnings("WeakerAccess")
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
 public class Stu3LocationController {
@@ -87,9 +86,8 @@ public class Stu3LocationController {
 
   /** Read raw. */
   @GetMapping(
-    value = {"/{publicId}"},
-    headers = {"raw=true"}
-  )
+      value = {"/{publicId}"},
+      headers = {"raw=true"})
   public String readRaw(@PathVariable("publicId") String publicId, HttpServletResponse response) {
     IncludesIcnMajig.addHeaderForNoPatients(response);
     return entityById(publicId).payload();
@@ -181,17 +179,15 @@ public class Stu3LocationController {
         entities.map(LocationEntity::asDatamartLocation).collect(Collectors.toList());
     witnessProtection.registerAndUpdateReferences(
         datamarts, resource -> Stream.of(resource.managingOrganization()));
-    return datamarts
-        .stream()
+    return datamarts.stream()
         .map(dm -> Stu3LocationTransformer.builder().datamart(dm).build().toFhir())
         .collect(Collectors.toList());
   }
 
   /** Hey, this is a validate endpoint. It validates. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody Location.Bundle bundle) {
     return Stu3Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medication/Dstu2MedicationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medication/Dstu2MedicationController.java
@@ -39,9 +39,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequestMapping(
-  value = {"/dstu2/Medication"},
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = {"/dstu2/Medication"},
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 public class Dstu2MedicationController {
 
   private Dstu2Bundler bundler;
@@ -90,9 +89,8 @@ public class Dstu2MedicationController {
 
   /** Read by id, raw data. */
   @GetMapping(
-    value = {"/{publicId}"},
-    headers = {"raw=true"}
-  )
+      value = {"/{publicId}"},
+      headers = {"raw=true"})
   public String readRaw(@PathVariable("publicId") String publicId, HttpServletResponse response) {
     IncludesIcnMajig.addHeaderForNoPatients(response);
     return findById(publicId).payload();
@@ -122,9 +120,8 @@ public class Dstu2MedicationController {
 
   /** Hey, this is a validate endpoint. It validates. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody Bundle bundle) {
     return Dstu2Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationdispense/Dstu2MedicationDispenseController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationdispense/Dstu2MedicationDispenseController.java
@@ -19,9 +19,8 @@ import org.springframework.web.bind.annotation.RestController;
 @SuppressWarnings("WeakerAccess")
 @RestController
 @RequestMapping(
-  value = {"/dstu2/MedicationDispense"},
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = {"/dstu2/MedicationDispense"},
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
 public class Dstu2MedicationDispenseController {
 
@@ -80,9 +79,8 @@ public class Dstu2MedicationDispenseController {
 
   /** Validation endpoint. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody MedicationDispense.Bundle bundle) {
     return Dstu2Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/Dstu2MedicationOrderController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/Dstu2MedicationOrderController.java
@@ -44,9 +44,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequestMapping(
-  value = {"/dstu2/MedicationOrder"},
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = {"/dstu2/MedicationOrder"},
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 public class Dstu2MedicationOrderController {
 
   private Dstu2Bundler bundler;
@@ -115,9 +114,8 @@ public class Dstu2MedicationOrderController {
 
   /** Read by id, raw data. */
   @GetMapping(
-    value = {"/{publicId}"},
-    headers = {"raw=true"}
-  )
+      value = {"/{publicId}"},
+      headers = {"raw=true"})
   public String readRaw(@PathVariable("publicId") String publicId, HttpServletResponse response) {
     MedicationOrderEntity entity = findById(publicId);
     IncludesIcnMajig.addHeader(response, entity.icn());
@@ -177,9 +175,8 @@ public class Dstu2MedicationOrderController {
 
   /** Validate Endpoint. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody MedicationOrder.Bundle bundle) {
     return Dstu2Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationstatement/Dstu2MedicationStatementController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationstatement/Dstu2MedicationStatementController.java
@@ -44,9 +44,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequestMapping(
-  value = {"/dstu2/MedicationStatement"},
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = {"/dstu2/MedicationStatement"},
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 public class Dstu2MedicationStatementController {
 
   private Dstu2Bundler bundler;
@@ -121,9 +120,8 @@ public class Dstu2MedicationStatementController {
 
   /** Read by id, raw data. */
   @GetMapping(
-    value = {"/{publicId}"},
-    headers = {"raw=true"}
-  )
+      value = {"/{publicId}"},
+      headers = {"raw=true"})
   public String readRaw(@PathVariable("publicId") String publicId, HttpServletResponse response) {
     MedicationStatementEntity entity = findById(publicId);
     IncludesIcnMajig.addHeader(response, entity.icn());
@@ -186,9 +184,8 @@ public class Dstu2MedicationStatementController {
 
   /** Hey, this is a validate endpoint. It validates. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody MedicationStatement.Bundle bundle) {
     return Dstu2Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/Dstu2ObservationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/Dstu2ObservationController.java
@@ -47,9 +47,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequestMapping(
-  value = {"/dstu2/Observation"},
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = {"/dstu2/Observation"},
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 public class Dstu2ObservationController {
 
   private Dstu2Bundler bundler;
@@ -92,8 +91,7 @@ public class Dstu2ObservationController {
         entitiesPage.stream().map(e -> e.asDatamartObservation()).collect(Collectors.toList());
     replaceReferences(datamarts);
     List<Observation> fhir =
-        datamarts
-            .stream()
+        datamarts.stream()
             .map(dm -> Dstu2ObservationTransformer.builder().datamart(dm).build().toFhir())
             .collect(Collectors.toList());
     return bundle(parameters, fhir, (int) entitiesPage.getTotalElements());
@@ -122,9 +120,8 @@ public class Dstu2ObservationController {
 
   /** Return the raw Datamart document for the given identifier. */
   @GetMapping(
-    value = "/{publicId}",
-    headers = {"raw=true"}
-  )
+      value = "/{publicId}",
+      headers = {"raw=true"})
   public String readRaw(@PathVariable("publicId") String publicId, HttpServletResponse response) {
     ObservationEntity entity = findById(publicId);
     IncludesIcnMajig.addHeader(response, entity.icn());
@@ -233,9 +230,8 @@ public class Dstu2ObservationController {
 
   /** Hey, this is a validate endpoint. It validates. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody Observation.Bundle bundle) {
     return Dstu2Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/Dstu2ObservationTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/Dstu2ObservationTransformer.java
@@ -296,9 +296,7 @@ final class Dstu2ObservationTransformer {
             datamart.vitalsComponents().size() + datamart.antibioticComponents().size() + 2);
     List<Observation.ObservationComponent> vitals =
         emptyToNull(
-            datamart
-                .vitalsComponents()
-                .stream()
+            datamart.vitalsComponents().stream()
                 .map(v -> component(v))
                 .collect(Collectors.toList()));
     if (vitals != null) {
@@ -306,9 +304,7 @@ final class Dstu2ObservationTransformer {
     }
     List<Observation.ObservationComponent> antibiotics =
         emptyToNull(
-            datamart
-                .antibioticComponents()
-                .stream()
+            datamart.antibioticComponents().stream()
                 .map(v -> component(v))
                 .collect(Collectors.toList()));
     if (antibiotics != null) {

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/organization/Dstu2OrganizationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/organization/Dstu2OrganizationController.java
@@ -35,9 +35,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequestMapping(
-  value = "/dstu2/Organization",
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = "/dstu2/Organization",
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 public class Dstu2OrganizationController {
 
   private Dstu2Bundler bundler;
@@ -87,9 +86,8 @@ public class Dstu2OrganizationController {
 
   /** Read by id. */
   @GetMapping(
-    value = {"/{publicId}"},
-    headers = {"raw=true"}
-  )
+      value = {"/{publicId}"},
+      headers = {"raw=true"})
   public String readRaw(@PathVariable("publicId") String publicId, HttpServletResponse response) {
     IncludesIcnMajig.addHeaderForNoPatients(response);
     return findById(publicId).payload();
@@ -127,9 +125,8 @@ public class Dstu2OrganizationController {
 
   /** Hey, this is a validate endpoint. It validates. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody Organization.Bundle bundle) {
     return Dstu2Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/organization/Stu3OrganizationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/organization/Stu3OrganizationController.java
@@ -42,9 +42,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequestMapping(
-  value = {"/stu3/Organization"},
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = {"/stu3/Organization"},
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 @SuppressWarnings("WeakerAccess")
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
 public class Stu3OrganizationController {
@@ -88,9 +87,8 @@ public class Stu3OrganizationController {
 
   /** Read raw. */
   @GetMapping(
-    value = {"/{publicId}"},
-    headers = {"raw=true"}
-  )
+      value = {"/{publicId}"},
+      headers = {"raw=true"})
   public String readRaw(@PathVariable("publicId") String publicId, HttpServletResponse response) {
     IncludesIcnMajig.addHeaderForNoPatients(response);
     return entityById(publicId).payload();
@@ -201,17 +199,15 @@ public class Stu3OrganizationController {
         entities.map(OrganizationEntity::asDatamartOrganization).collect(Collectors.toList());
     witnessProtection.registerAndUpdateReferences(
         datamarts, resource -> resource.partOf().stream());
-    return datamarts
-        .stream()
+    return datamarts.stream()
         .map(dm -> Stu3OrganizationTransformer.builder().datamart(dm).build().toFhir())
         .collect(Collectors.toList());
   }
 
   /** Hey, this is a validate endpoint. It validates. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody Organization.Bundle bundle) {
     return Stu3Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/Dstu2PatientController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/Dstu2PatientController.java
@@ -1,5 +1,6 @@
 package gov.va.api.health.dataquery.service.controller.patient;
 
+import static gov.va.api.health.autoconfig.logging.LogSanitizer.sanitize;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
@@ -13,6 +14,8 @@ import gov.va.api.health.dataquery.service.controller.Parameters;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dstu2.api.resources.OperationOutcome;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -42,9 +45,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @SuppressWarnings("WeakerAccess")
 @RequestMapping(
-  value = {"/dstu2/Patient"},
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = {"/dstu2/Patient"},
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 public class Dstu2PatientController {
 
   private Dstu2Bundler bundler;
@@ -120,9 +122,8 @@ public class Dstu2PatientController {
 
   /** Return the raw Datamart document for the given identifier. */
   @GetMapping(
-    value = "/{publicId}",
-    headers = {"raw=true"}
-  )
+      value = "/{publicId}",
+      headers = {"raw=true"})
   public String readRaw(@PathVariable("publicId") String publicId, HttpServletResponse response) {
     PatientSearchEntity entity = findById(publicId);
     IncludesIcnMajig.addHeader(response, entity.icn());
@@ -204,7 +205,9 @@ public class Dstu2PatientController {
             .name(name)
             .dates(birthdate)
             .build();
-    log.info("Looking for {} {}", name, spec);
+    URLEncoder.encode(name, StandardCharsets.UTF_8);
+
+    log.info("Looking for {} {}", sanitize(name), spec);
     Page<PatientSearchEntity> entities = repository.findAll(spec, page(page, count));
     return bundle(
         Parameters.builder()
@@ -239,9 +242,8 @@ public class Dstu2PatientController {
 
   /** Hey, this is a validate endpoint. It validates. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody Patient.Bundle bundle) {
     return Dstu2Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/PatientBulkFhirController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/PatientBulkFhirController.java
@@ -19,9 +19,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @SuppressWarnings("WeakerAccess")
 @RequestMapping(
-  value = {"/internal/bulk/Patient"},
-  produces = {"application/json", "application/fhir+json", "application/json+fhir"}
-)
+    value = {"/internal/bulk/Patient"},
+    produces = {"application/json", "application/fhir+json", "application/json+fhir"})
 public class PatientBulkFhirController {
 
   private PatientRepository repository;
@@ -56,9 +55,7 @@ public class PatientBulkFhirController {
       @RequestParam(value = "page", defaultValue = "1") @Min(1) int page,
       @RequestParam(value = "_count", defaultValue = "15") @Min(0) int count) {
     PageAndCountValidator.validateCountBounds(count, maxRecordsPerPage);
-    return repository
-        .findAllProjectedBy(page(page, count))
-        .stream()
+    return repository.findAllProjectedBy(page(page, count)).stream()
         .map(PatientPayloadDto::asDatamartPatient)
         .map(dm -> Dstu2PatientTransformer.builder().datamart(dm).build().toFhir())
         .collect(Collectors.toList());

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerController.java
@@ -38,9 +38,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @SuppressWarnings("WeakerAccess")
 @RequestMapping(
-  value = {"/dstu2/Practitioner"},
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = {"/dstu2/Practitioner"},
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 public class Dstu2PractitionerController {
 
   private Dstu2Bundler bundler;
@@ -93,9 +92,8 @@ public class Dstu2PractitionerController {
 
   /** Read by id. */
   @GetMapping(
-    value = {"/{publicId}"},
-    headers = {"raw=true"}
-  )
+      value = {"/{publicId}"},
+      headers = {"raw=true"})
   public String readRaw(@PathVariable("publicId") String publicId, HttpServletResponse response) {
     PractitionerEntity entity = findById(publicId);
     IncludesIcnMajig.addHeaderForNoPatients(response);
@@ -108,9 +106,7 @@ public class Dstu2PractitionerController {
         resources,
         resource ->
             Stream.concat(
-                resource
-                    .practitionerRole()
-                    .stream()
+                resource.practitionerRole().stream()
                     .map(role -> role.managingOrganization().orElse(null)),
                 resource.practitionerRole().stream().flatMap(role -> role.location().stream())));
     return resources;
@@ -144,9 +140,8 @@ public class Dstu2PractitionerController {
 
   /** Hey, this is a validate endpoint. It validates. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody Practitioner.Bundle bundle) {
     return Dstu2Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerTransformer.java
@@ -91,9 +91,7 @@ public class Dstu2PractitionerTransformer {
     return Practitioner.PractitionerRole.builder()
         .location(
             emptyToNull(
-                source
-                    .location()
-                    .stream()
+                source.location().stream()
                     .map(loc -> asReference(loc))
                     .collect(Collectors.toList())))
         .role(asCodeableConceptWrapping(source.role()))
@@ -138,9 +136,7 @@ public class Dstu2PractitionerTransformer {
 
   List<Practitioner.PractitionerRole> practitionerRoles() {
     return emptyToNull(
-        datamart
-            .practitionerRole()
-            .stream()
+        datamart.practitionerRole().stream()
             .map(rol -> practitionerRole(rol))
             .collect(Collectors.toList()));
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Stu3PractitionerController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Stu3PractitionerController.java
@@ -42,9 +42,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @SuppressWarnings("WeakerAccess")
 @RequestMapping(
-  value = {"/stu3/Practitioner"},
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = {"/stu3/Practitioner"},
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
 public class Stu3PractitionerController {
 
@@ -88,9 +87,8 @@ public class Stu3PractitionerController {
 
   /** Read raw. */
   @GetMapping(
-    value = {"/{publicId}"},
-    headers = {"raw=true"}
-  )
+      value = {"/{publicId}"},
+      headers = {"raw=true"})
   public String readRaw(@PathVariable("publicId") String publicId, HttpServletResponse response) {
     PractitionerEntity entity = findById(publicId);
     IncludesIcnMajig.addHeaderForNoPatients(response);
@@ -103,9 +101,7 @@ public class Stu3PractitionerController {
         resources,
         resource ->
             Stream.concat(
-                resource
-                    .practitionerRole()
-                    .stream()
+                resource.practitionerRole().stream()
                     .map(role -> role.managingOrganization().orElse(null)),
                 resource.practitionerRole().stream().flatMap(role -> role.location().stream())));
     return resources;
@@ -186,8 +182,7 @@ public class Stu3PractitionerController {
     List<DatamartPractitioner> datamarts =
         entities.map(PractitionerEntity::asDatamartPractitioner).collect(Collectors.toList());
     replaceReferences(datamarts);
-    return datamarts
-        .stream()
+    return datamarts.stream()
         .map(dm -> Stu3PractitionerTransformer.builder().datamart(dm).build().toFhir())
         .collect(Collectors.toList());
   }
@@ -198,9 +193,8 @@ public class Stu3PractitionerController {
 
   /** Hey, this is a validate endpoint. It validates. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody Practitioner.Bundle bundle) {
     return Stu3Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitionerrole/Stu3PractitionerRoleController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitionerrole/Stu3PractitionerRoleController.java
@@ -44,9 +44,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequestMapping(
-  value = "/stu3/PractitionerRole",
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = "/stu3/PractitionerRole",
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 @SuppressWarnings("WeakerAccess")
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
 public class Stu3PractitionerRoleController {
@@ -91,9 +90,8 @@ public class Stu3PractitionerRoleController {
 
   /** Read raw. */
   @GetMapping(
-    value = {"/{publicId}"},
-    headers = {"raw=true"}
-  )
+      value = {"/{publicId}"},
+      headers = {"raw=true"})
   public String readRaw(@PathVariable("publicId") String publicId, HttpServletResponse response) {
     IncludesIcnMajig.addHeaderForNoPatients(response);
     return entityById(publicId).payload();
@@ -196,22 +194,18 @@ public class Stu3PractitionerRoleController {
         datamarts,
         resource ->
             Stream.concat(
-                resource
-                    .practitionerRole()
-                    .stream()
+                resource.practitionerRole().stream()
                     .map(role -> role.managingOrganization().orElse(null)),
                 resource.practitionerRole().stream().flatMap(role -> role.location().stream())));
-    return datamarts
-        .stream()
+    return datamarts.stream()
         .map(dm -> Stu3PractitionerRoleTransformer.builder().datamart(dm).build().toFhir())
         .collect(Collectors.toList());
   }
 
   /** Hey, this is a validate endpoint. It validates. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody PractitionerRole.Bundle bundle) {
     return Stu3Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/procedure/Dstu2ProcedureController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/procedure/Dstu2ProcedureController.java
@@ -1,5 +1,6 @@
 package gov.va.api.health.dataquery.service.controller.procedure;
 
+import static gov.va.api.health.autoconfig.logging.LogSanitizer.sanitize;
 import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -55,9 +56,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequestMapping(
-  value = {"/dstu2/Procedure"},
-  produces = {"application/json", "application/json+fhir", "application/fhir+json"}
-)
+    value = {"/dstu2/Procedure"},
+    produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 public class Dstu2ProcedureController {
 
   /**
@@ -177,9 +177,8 @@ public class Dstu2ProcedureController {
 
   /** Return the raw Datamart document for the given identifier. */
   @GetMapping(
-    value = {"/{publicId}"},
-    headers = {"raw=true"}
-  )
+      value = {"/{publicId}"},
+      headers = {"raw=true"})
   public String readRaw(
       @PathVariable("publicId") String publicId,
       @RequestHeader(value = "X-VA-ICN", required = false) String icnHeader,
@@ -188,9 +187,7 @@ public class Dstu2ProcedureController {
     if (isNotBlank(icnHeader)
         && isPatientWithoutRecords(icnHeader)
         && entity.icn().equals(withRecordsId)) {
-      log.info(
-          "Procedure Hack: Setting includes header to magic patient: {}",
-          icnHeader.replaceAll("[\r\n]", ""));
+      log.info("Procedure Hack: Setting includes header to magic patient: {}", sanitize(icnHeader));
       IncludesIcnMajig.addHeader(response, IncludesIcnMajig.encodeHeaderValue(icnHeader));
     } else {
       IncludesIcnMajig.addHeader(response, IncludesIcnMajig.encodeHeaderValue(entity.icn()));
@@ -293,9 +290,8 @@ public class Dstu2ProcedureController {
 
   /** Hey, this is a validate endpoint. It validates. */
   @PostMapping(
-    value = "/$validate",
-    consumes = {"application/json", "application/json+fhir", "application/fhir+json"}
-  )
+      value = "/$validate",
+      consumes = {"application/json", "application/json+fhir", "application/fhir+json"})
   public OperationOutcome validate(@RequestBody Procedure.Bundle bundle) {
     return Dstu2Validator.create().validate(bundle);
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/validation/DatamartValidationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/validation/DatamartValidationController.java
@@ -35,9 +35,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequestMapping(
-  value = {"/datamart/validation"},
-  produces = {"application/json"}
-)
+    value = {"/datamart/validation"},
+    produces = {"application/json"})
 public class DatamartValidationController {
 
   private static Map<String, Class<?>> datamartResources =

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/wellknown/WellKnownController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/wellknown/WellKnownController.java
@@ -10,9 +10,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping(
-  value = {"/.well-known/smart-configuration"},
-  produces = {"application/json", "application/fhir+json", "application/json+fhir"}
-)
+    value = {"/.well-known/smart-configuration"},
+    produces = {"application/json", "application/fhir+json", "application/json+fhir"})
 @AllArgsConstructor(onConstructor = @__({@Autowired}))
 class WellKnownController {
   private final WellKnownProperties wellKnownProperties;

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/config/Dstu2JacksonMapperTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/config/Dstu2JacksonMapperTest.java
@@ -169,9 +169,8 @@ public class Dstu2JacksonMapperTest {
   @NoArgsConstructor(access = AccessLevel.PRIVATE)
   @AllArgsConstructor
   @JsonAutoDetect(
-    fieldVisibility = JsonAutoDetect.Visibility.ANY,
-    isGetterVisibility = JsonAutoDetect.Visibility.NONE
-  )
+      fieldVisibility = JsonAutoDetect.Visibility.ANY,
+      isGetterVisibility = JsonAutoDetect.Visibility.NONE)
   static final class FugaziReferenceMajig {
     Reference ref;
     Reference nope;
@@ -189,9 +188,8 @@ public class Dstu2JacksonMapperTest {
   @AllArgsConstructor
   @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   @ExactlyOneOf(
-    fields = {"required", "_required"},
-    message = "Exactly one required field must be specified"
-  )
+      fields = {"required", "_required"},
+      message = "Exactly one required field must be specified")
   static final class FugaziRequiredReferenceMajig {
     Reference required;
     Extension _required;

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/config/Stu3JacksonMapperTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/config/Stu3JacksonMapperTest.java
@@ -169,9 +169,8 @@ public class Stu3JacksonMapperTest {
   @NoArgsConstructor(access = AccessLevel.PRIVATE)
   @AllArgsConstructor
   @JsonAutoDetect(
-    fieldVisibility = JsonAutoDetect.Visibility.ANY,
-    isGetterVisibility = JsonAutoDetect.Visibility.NONE
-  )
+      fieldVisibility = JsonAutoDetect.Visibility.ANY,
+      isGetterVisibility = JsonAutoDetect.Visibility.NONE)
   static final class FugaziReferenceMajig {
     Reference ref;
     Reference nope;
@@ -189,9 +188,8 @@ public class Stu3JacksonMapperTest {
   @AllArgsConstructor
   @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   @ExactlyOneOf(
-    fields = {"required", "_required"},
-    message = "Exactly one required field must be specified"
-  )
+      fields = {"required", "_required"},
+      message = "Exactly one required field must be specified")
   static final class FugaziRequiredReferenceMajig {
     Reference required;
     Extension _required;

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/AllergyIntoleranceSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/AllergyIntoleranceSamples.java
@@ -171,8 +171,7 @@ public class AllergyIntoleranceSamples {
           .total(totalRecords)
           .link(Arrays.asList(links))
           .entry(
-              resources
-                  .stream()
+              resources.stream()
                   .map(
                       a ->
                           AllergyIntolerance.Entry.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/condition/ConditionSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/condition/ConditionSamples.java
@@ -95,8 +95,7 @@ public class ConditionSamples {
           .total(totalRecords)
           .link(Arrays.asList(links))
           .entry(
-              conditions
-                  .stream()
+              conditions.stream()
                   .map(
                       c ->
                           Entry.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/condition/Dstu2ConditionControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/condition/Dstu2ConditionControllerTest.java
@@ -223,15 +223,11 @@ public class Dstu2ConditionControllerTest {
             json(
                 Dstu2.asBundle(
                     "http://fonzy.com/cool",
-                    conditionsByPatient
-                        .get("p0")
-                        .stream()
+                    conditionsByPatient.get("p0").stream()
                         .filter(c -> "Diagnosis".equalsIgnoreCase(c.category().text()))
                         .collect(Collectors.toList()),
                     (int)
-                        conditionsByPatient
-                            .get("p0")
-                            .stream()
+                        conditionsByPatient.get("p0").stream()
                             .filter(c -> "Diagnosis".equalsIgnoreCase(c.category().text()))
                             .count(),
                     link(
@@ -259,15 +255,11 @@ public class Dstu2ConditionControllerTest {
             json(
                 Dstu2.asBundle(
                     "http://fonzy.com/cool",
-                    conditionsByPatient
-                        .get("p0")
-                        .stream()
+                    conditionsByPatient.get("p0").stream()
                         .filter(c -> Condition.ClinicalStatusCode.active == c.clinicalStatus())
                         .collect(Collectors.toList()),
                     (int)
-                        conditionsByPatient
-                            .get("p0")
-                            .stream()
+                        conditionsByPatient.get("p0").stream()
                             .filter(c -> Condition.ClinicalStatusCode.active == c.clinicalStatus())
                             .count(),
                     link(

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/DiagnosticReportSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/DiagnosticReportSamples.java
@@ -107,8 +107,7 @@ public class DiagnosticReportSamples {
           .total(totalRecords)
           .link(Arrays.asList(links))
           .entry(
-              reports
-                  .stream()
+              reports.stream()
                   .map(
                       c ->
                           Entry.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/immunization/ImmunizationSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/immunization/ImmunizationSamples.java
@@ -113,8 +113,7 @@ public class ImmunizationSamples {
           .total(totalRecords)
           .link(Arrays.asList(links))
           .entry(
-              immunizations
-                  .stream()
+              immunizations.stream()
                   .map(
                       c ->
                           Entry.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/location/Dstu2LocationSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/location/Dstu2LocationSamples.java
@@ -28,8 +28,7 @@ final class Dstu2LocationSamples {
         .total(locations.size())
         .link(Arrays.asList(links))
         .entry(
-            locations
-                .stream()
+            locations.stream()
                 .map(
                     c ->
                         Location.Entry.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/location/Stu3LocationSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/location/Stu3LocationSamples.java
@@ -27,8 +27,7 @@ final class Stu3LocationSamples {
         .total(locations.size())
         .link(Arrays.asList(links))
         .entry(
-            locations
-                .stream()
+            locations.stream()
                 .map(
                     c ->
                         Location.Entry.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medication/MedicationSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medication/MedicationSamples.java
@@ -61,8 +61,7 @@ public class MedicationSamples {
           .total(totalRecords)
           .link(Arrays.asList(links))
           .entry(
-              medications
-                  .stream()
+              medications.stream()
                   .map(
                       c ->
                           Medication.Entry.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/MedicationOrderSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationorder/MedicationOrderSamples.java
@@ -111,8 +111,7 @@ public class MedicationOrderSamples {
           .total(totalRecords)
           .link(asList(links))
           .entry(
-              records
-                  .stream()
+              records.stream()
                   .map(
                       c ->
                           MedicationOrder.Entry.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationstatement/MedicationStatementSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/medicationstatement/MedicationStatementSamples.java
@@ -76,8 +76,7 @@ public class MedicationStatementSamples {
           .total(totalRecords)
           .link(Arrays.asList(links))
           .entry(
-              medicationStatements
-                  .stream()
+              medicationStatements.stream()
                   .map(
                       c ->
                           Entry.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/observation/Dstu2ObservationControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/observation/Dstu2ObservationControllerTest.java
@@ -266,9 +266,7 @@ public class Dstu2ObservationControllerTest {
   public void searchByPatientAndCategory() {
     Multimap<String, Observation> observationsByPatient = populateData();
     List<Observation> observations =
-        observationsByPatient
-            .get("p0")
-            .stream()
+        observationsByPatient.get("p0").stream()
             .filter(c -> "laboratory".equalsIgnoreCase(c.category().coding().get(0).code()))
             .collect(Collectors.toList());
     assertThat(json(controller().searchByPatientAndCategory("p0", "laboratory", null, 1, 10)))
@@ -294,9 +292,7 @@ public class Dstu2ObservationControllerTest {
                         1,
                         10))));
     List<Observation> patient1Observations =
-        observationsByPatient
-            .get("p1")
-            .stream()
+        observationsByPatient.get("p1").stream()
             .filter(c -> "vital-signs".equalsIgnoreCase(c.category().coding().get(0).code()))
             .collect(Collectors.toList());
     assertThat(json(controller().searchByPatientAndCategory("p1", "vital-signs", null, 1, 10)))
@@ -364,9 +360,7 @@ public class Dstu2ObservationControllerTest {
     testDates.putAll("sa2005-01-14", List.of());
     for (var date : testDates.keySet()) {
       List<Observation> observations =
-          observationsByPatient
-              .get("p0")
-              .stream()
+          observationsByPatient.get("p0").stream()
               .filter(o -> testDates.get(date).contains(o.effectiveDateTime()))
               .collect(Collectors.toList());
       assertThat(
@@ -435,9 +429,7 @@ public class Dstu2ObservationControllerTest {
     testDates.putAll(Pair.of("gt2005-01-13", "lt2005-01-15"), List.of("2005-01-14T07:57:00Z"));
     for (var date : testDates.keySet()) {
       List<Observation> observations =
-          observationsByPatient
-              .get("p0")
-              .stream()
+          observationsByPatient.get("p0").stream()
               .filter(o -> testDates.get(date).contains(o.effectiveDateTime()))
               .collect(Collectors.toList());
       assertThat(
@@ -489,9 +481,7 @@ public class Dstu2ObservationControllerTest {
   public void searchByPatientAndCode() {
     Multimap<String, Observation> observationsByPatient = populateData();
     List<Observation> patient0Observations =
-        observationsByPatient
-            .get("p0")
-            .stream()
+        observationsByPatient.get("p0").stream()
             .filter(c -> "1989-3".equalsIgnoreCase(c.code().coding().get(0).code()))
             .collect(Collectors.toList());
     assertThat(json(controller().searchByPatientAndCode("p0", "1989-3", 1, 10)))
@@ -517,9 +507,7 @@ public class Dstu2ObservationControllerTest {
                         1,
                         10))));
     List<Observation> patient1Observations =
-        observationsByPatient
-            .get("p1")
-            .stream()
+        observationsByPatient.get("p1").stream()
             .filter(c -> "8480-6".equalsIgnoreCase(c.code().coding().get(0).code()))
             .collect(Collectors.toList());
     assertThat(json(controller().searchByPatientAndCode("p1", "8480-6", 1, 10)))
@@ -583,9 +571,7 @@ public class Dstu2ObservationControllerTest {
         List.of("2005-01-14T07:57:00Z", "2005-01-16T07:57:00Z"));
     for (var date : testDates.keySet()) {
       List<Observation> observations =
-          observationsByPatient
-              .get("p0")
-              .stream()
+          observationsByPatient.get("p0").stream()
               .filter(o -> testDates.get(date).contains(o.effectiveDateTime()))
               .collect(Collectors.toList());
       assertThat(

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/observation/Dstu2ObservationControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/observation/Dstu2ObservationControllerTest.java
@@ -263,64 +263,7 @@ public class Dstu2ObservationControllerTest {
   }
 
   @Test
-  public void searchByPatientAndCategory() {
-    Multimap<String, Observation> observationsByPatient = populateData();
-    List<Observation> observations =
-        observationsByPatient.get("p0").stream()
-            .filter(c -> "laboratory".equalsIgnoreCase(c.category().coding().get(0).code()))
-            .collect(Collectors.toList());
-    assertThat(json(controller().searchByPatientAndCategory("p0", "laboratory", null, 1, 10)))
-        .isEqualTo(
-            json(
-                Dstu2.asBundle(
-                    "http://fonzy.com/cool",
-                    observations,
-                    observations.size(),
-                    link(
-                        LinkRelation.first,
-                        "http://fonzy.com/cool/Observation?category=laboratory&patient=p0",
-                        1,
-                        10),
-                    link(
-                        LinkRelation.self,
-                        "http://fonzy.com/cool/Observation?category=laboratory&patient=p0",
-                        1,
-                        10),
-                    link(
-                        LinkRelation.last,
-                        "http://fonzy.com/cool/Observation?category=laboratory&patient=p0",
-                        1,
-                        10))));
-    List<Observation> patient1Observations =
-        observationsByPatient.get("p1").stream()
-            .filter(c -> "vital-signs".equalsIgnoreCase(c.category().coding().get(0).code()))
-            .collect(Collectors.toList());
-    assertThat(json(controller().searchByPatientAndCategory("p1", "vital-signs", null, 1, 10)))
-        .isEqualTo(
-            json(
-                Dstu2.asBundle(
-                    "http://fonzy.com/cool",
-                    patient1Observations,
-                    patient1Observations.size(),
-                    link(
-                        LinkRelation.first,
-                        "http://fonzy.com/cool/Observation?category=vital-signs&patient=p1",
-                        1,
-                        10),
-                    link(
-                        LinkRelation.self,
-                        "http://fonzy.com/cool/Observation?category=vital-signs&patient=p1",
-                        1,
-                        10),
-                    link(
-                        LinkRelation.last,
-                        "http://fonzy.com/cool/Observation?category=vital-signs&patient=p1",
-                        1,
-                        10))));
-  }
-
-  @Test
-  public void searchByPatientAndCategoryAndOneDate() {
+  public void searchByPatientAndCategoryAndOneDateHack() {
     /*
     This test exhaustively verifies all of the different date prefixes
     in combination with patient and category.
@@ -366,7 +309,8 @@ public class Dstu2ObservationControllerTest {
       assertThat(
               json(
                   controller()
-                      .searchByPatientAndCategory("p0", "laboratory", new String[] {date}, 1, 10)))
+                      .searchByPatientAndCategory(
+                          true, "p0", "laboratory", new String[] {date}, 1, 10)))
           .isEqualTo(
               json(
                   Dstu2.asBundle(
@@ -398,7 +342,86 @@ public class Dstu2ObservationControllerTest {
   }
 
   @Test
-  public void searchByPatientAndCategoryAndTwoDates() {
+  public void searchByPatientAndCategoryAndOneDateNoHack() {
+    /*
+    This test exhaustively verifies all of the different date prefixes
+    in combination with patient and category.
+
+    Observation dates for p0
+     2005-01-10T07:57:00Z -> laboratory
+     2005-01-12T07:57:00Z -> laboratory
+     2005-01-14T07:57:00Z -> laboratory
+     2005-01-16T07:57:00Z -> vital-signs
+     2005-01-18T07:57:00Z -> vital-signs
+
+    Observation dates for p1
+     2005-01-11T07:57:00Z -> laboratory
+     2005-01-13T07:57:00Z -> laboratory
+     2005-01-15T07:57:00Z -> vital-signs
+     2005-01-17T07:57:00Z -> vital-signs
+     2005-01-19T07:57:00Z -> vital-signs
+    */
+    Multimap<String, Observation> observationsByPatient = populateData();
+    /*
+    <criteria, expected dates>
+    key: search criteria (prefix + date)
+    value: expected date responses
+     */
+    Multimap<String, String> testDates = LinkedHashMultimap.create();
+    testDates.putAll(
+        "gt2004", List.of("2005-01-10T07:57:00Z", "2005-01-12T07:57:00Z", "2005-01-14T07:57:00Z"));
+    testDates.putAll("eq2005-01-14", List.of("2005-01-14T07:57:00Z"));
+    testDates.putAll("ne2005-01-14", List.of("2005-01-10T07:57:00Z", "2005-01-12T07:57:00Z"));
+    testDates.putAll(
+        "le2005-01-14",
+        List.of("2005-01-10T07:57:00Z", "2005-01-12T07:57:00Z", "2005-01-14T07:57:00Z"));
+    testDates.putAll("lt2005-01-14", List.of("2005-01-10T07:57:00Z", "2005-01-12T07:57:00Z"));
+    testDates.putAll("eb2005-01-14", List.of("2005-01-10T07:57:00Z", "2005-01-12T07:57:00Z"));
+    testDates.putAll("ge2005-01-14", List.of("2005-01-14T07:57:00Z"));
+    testDates.putAll("gt2005-01-14", List.of());
+    testDates.putAll("sa2005-01-14", List.of());
+    for (var date : testDates.keySet()) {
+      List<Observation> observations =
+          observationsByPatient.get("p0").stream()
+              .filter(o -> testDates.get(date).contains(o.effectiveDateTime()))
+              .collect(Collectors.toList());
+      assertThat(
+              json(
+                  controller()
+                      .searchByPatientAndCategory(
+                          false, "p0", "laboratory", new String[] {date}, 1, 10)))
+          .isEqualTo(
+              json(
+                  Dstu2.asBundle(
+                      "http://fonzy.com/cool",
+                      observations,
+                      observations.size(),
+                      link(
+                          LinkRelation.first,
+                          "http://fonzy.com/cool/Observation?category=laboratory&date="
+                              + date
+                              + "&patient=p0",
+                          1,
+                          10),
+                      link(
+                          LinkRelation.self,
+                          "http://fonzy.com/cool/Observation?category=laboratory&date="
+                              + date
+                              + "&patient=p0",
+                          1,
+                          10),
+                      link(
+                          LinkRelation.last,
+                          "http://fonzy.com/cool/Observation?category=laboratory&date="
+                              + date
+                              + "&patient=p0",
+                          1,
+                          10))));
+    }
+  }
+
+  @Test
+  public void searchByPatientAndCategoryAndTwoDatesHack() {
     /*
     The single date test does exhaustive date-prefix searching. We won't do that here.
 
@@ -436,6 +459,7 @@ public class Dstu2ObservationControllerTest {
               json(
                   controller()
                       .searchByPatientAndCategory(
+                          true,
                           "p0",
                           "laboratory",
                           new String[] {date.getLeft(), date.getRight()},
@@ -475,6 +499,204 @@ public class Dstu2ObservationControllerTest {
                           1,
                           10))));
     }
+  }
+
+  @Test
+  public void searchByPatientAndCategoryAndTwoDatesNoHack() {
+    /*
+    The single date test does exhaustive date-prefix searching. We won't do that here.
+
+    Observation dates for p0
+     2005-01-10T07:57:00Z -> laboratory
+     2005-01-12T07:57:00Z -> laboratory
+     2005-01-14T07:57:00Z -> laboratory
+     2005-01-16T07:57:00Z -> vital-signs
+     2005-01-18T07:57:00Z -> vital-signs
+
+    Observation dates for p1
+     2005-01-11T07:57:00Z -> laboratory
+     2005-01-13T07:57:00Z -> laboratory
+     2005-01-15T07:57:00Z -> vital-signs
+     2005-01-17T07:57:00Z -> vital-signs
+     2005-01-19T07:57:00Z -> vital-signs
+     */
+    Multimap<String, Observation> observationsByPatient = populateData();
+    /*
+    <criteria, expected dates>
+    key: search criteria (prefix + date)
+    value: expected date responses
+     */
+    Multimap<Pair<String, String>, String> testDates = LinkedHashMultimap.create();
+    testDates.putAll(
+        Pair.of("gt2004", "lt2006"),
+        List.of("2005-01-10T07:57:00Z", "2005-01-12T07:57:00Z", "2005-01-14T07:57:00Z"));
+    testDates.putAll(Pair.of("gt2005-01-13", "lt2005-01-15"), List.of("2005-01-14T07:57:00Z"));
+    for (var date : testDates.keySet()) {
+      List<Observation> observations =
+          observationsByPatient.get("p0").stream()
+              .filter(o -> testDates.get(date).contains(o.effectiveDateTime()))
+              .collect(Collectors.toList());
+      assertThat(
+              json(
+                  controller()
+                      .searchByPatientAndCategory(
+                          false,
+                          "p0",
+                          "laboratory",
+                          new String[] {date.getLeft(), date.getRight()},
+                          1,
+                          10)))
+          .isEqualTo(
+              json(
+                  Dstu2.asBundle(
+                      "http://fonzy.com/cool",
+                      observations,
+                      observations.size(),
+                      link(
+                          LinkRelation.first,
+                          "http://fonzy.com/cool/Observation?category=laboratory&date="
+                              + date.getLeft()
+                              + "&date="
+                              + date.getRight()
+                              + "&patient=p0",
+                          1,
+                          10),
+                      link(
+                          LinkRelation.self,
+                          "http://fonzy.com/cool/Observation?category=laboratory&date="
+                              + date.getLeft()
+                              + "&date="
+                              + date.getRight()
+                              + "&patient=p0",
+                          1,
+                          10),
+                      link(
+                          LinkRelation.last,
+                          "http://fonzy.com/cool/Observation?category=laboratory&date="
+                              + date.getLeft()
+                              + "&date="
+                              + date.getRight()
+                              + "&patient=p0",
+                          1,
+                          10))));
+    }
+  }
+
+  @Test
+  public void searchByPatientAndCategoryHack() {
+    Multimap<String, Observation> observationsByPatient = populateData();
+    List<Observation> observations =
+        observationsByPatient.get("p0").stream()
+            .filter(c -> "laboratory".equalsIgnoreCase(c.category().coding().get(0).code()))
+            .collect(Collectors.toList());
+    assertThat(json(controller().searchByPatientAndCategory(true, "p0", "laboratory", null, 1, 10)))
+        .isEqualTo(
+            json(
+                Dstu2.asBundle(
+                    "http://fonzy.com/cool",
+                    observations,
+                    observations.size(),
+                    link(
+                        LinkRelation.first,
+                        "http://fonzy.com/cool/Observation?category=laboratory&patient=p0",
+                        1,
+                        10),
+                    link(
+                        LinkRelation.self,
+                        "http://fonzy.com/cool/Observation?category=laboratory&patient=p0",
+                        1,
+                        10),
+                    link(
+                        LinkRelation.last,
+                        "http://fonzy.com/cool/Observation?category=laboratory&patient=p0",
+                        1,
+                        10))));
+    List<Observation> patient1Observations =
+        observationsByPatient.get("p1").stream()
+            .filter(c -> "vital-signs".equalsIgnoreCase(c.category().coding().get(0).code()))
+            .collect(Collectors.toList());
+    assertThat(
+            json(controller().searchByPatientAndCategory(true, "p1", "vital-signs", null, 1, 10)))
+        .isEqualTo(
+            json(
+                Dstu2.asBundle(
+                    "http://fonzy.com/cool",
+                    patient1Observations,
+                    patient1Observations.size(),
+                    link(
+                        LinkRelation.first,
+                        "http://fonzy.com/cool/Observation?category=vital-signs&patient=p1",
+                        1,
+                        10),
+                    link(
+                        LinkRelation.self,
+                        "http://fonzy.com/cool/Observation?category=vital-signs&patient=p1",
+                        1,
+                        10),
+                    link(
+                        LinkRelation.last,
+                        "http://fonzy.com/cool/Observation?category=vital-signs&patient=p1",
+                        1,
+                        10))));
+  }
+
+  @Test
+  public void searchByPatientAndCategoryNoHack() {
+    Multimap<String, Observation> observationsByPatient = populateData();
+    List<Observation> observations =
+        observationsByPatient.get("p0").stream()
+            .filter(c -> "laboratory".equalsIgnoreCase(c.category().coding().get(0).code()))
+            .collect(Collectors.toList());
+    assertThat(
+            json(controller().searchByPatientAndCategory(false, "p0", "laboratory", null, 1, 10)))
+        .isEqualTo(
+            json(
+                Dstu2.asBundle(
+                    "http://fonzy.com/cool",
+                    observations,
+                    observations.size(),
+                    link(
+                        LinkRelation.first,
+                        "http://fonzy.com/cool/Observation?category=laboratory&patient=p0",
+                        1,
+                        10),
+                    link(
+                        LinkRelation.self,
+                        "http://fonzy.com/cool/Observation?category=laboratory&patient=p0",
+                        1,
+                        10),
+                    link(
+                        LinkRelation.last,
+                        "http://fonzy.com/cool/Observation?category=laboratory&patient=p0",
+                        1,
+                        10))));
+    List<Observation> patient1Observations =
+        observationsByPatient.get("p1").stream()
+            .filter(c -> "vital-signs".equalsIgnoreCase(c.category().coding().get(0).code()))
+            .collect(Collectors.toList());
+    assertThat(
+            json(controller().searchByPatientAndCategory(false, "p1", "vital-signs", null, 1, 10)))
+        .isEqualTo(
+            json(
+                Dstu2.asBundle(
+                    "http://fonzy.com/cool",
+                    patient1Observations,
+                    patient1Observations.size(),
+                    link(
+                        LinkRelation.first,
+                        "http://fonzy.com/cool/Observation?category=vital-signs&patient=p1",
+                        1,
+                        10),
+                    link(
+                        LinkRelation.self,
+                        "http://fonzy.com/cool/Observation?category=vital-signs&patient=p1",
+                        1,
+                        10),
+                    link(
+                        LinkRelation.last,
+                        "http://fonzy.com/cool/Observation?category=vital-signs&patient=p1",
+                        1,
+                        10))));
   }
 
   @Test
@@ -535,7 +757,7 @@ public class Dstu2ObservationControllerTest {
   }
 
   @Test
-  public void searchByPatientAndTwoCategoriesAndTwoDates() {
+  public void searchByPatientAndTwoCategoriesAndTwoDatesHack() {
     /*
     Observation dates for p0
      2005-01-10T07:57:00Z -> laboratory
@@ -578,6 +800,93 @@ public class Dstu2ObservationControllerTest {
               json(
                   controller()
                       .searchByPatientAndCategory(
+                          true,
+                          "p0",
+                          "laboratory,vital-signs",
+                          new String[] {date.getLeft(), date.getRight()},
+                          1,
+                          10)))
+          .isEqualTo(
+              json(
+                  Dstu2.asBundle(
+                      "http://fonzy.com/cool",
+                      observations,
+                      observations.size(),
+                      link(
+                          LinkRelation.first,
+                          "http://fonzy.com/cool/Observation?category=laboratory,vital-signs&date="
+                              + date.getLeft()
+                              + "&date="
+                              + date.getRight()
+                              + "&patient=p0",
+                          1,
+                          10),
+                      link(
+                          LinkRelation.self,
+                          "http://fonzy.com/cool/Observation?category=laboratory,vital-signs&date="
+                              + date.getLeft()
+                              + "&date="
+                              + date.getRight()
+                              + "&patient=p0",
+                          1,
+                          10),
+                      link(
+                          LinkRelation.last,
+                          "http://fonzy.com/cool/Observation?category=laboratory,vital-signs&date="
+                              + date.getLeft()
+                              + "&date="
+                              + date.getRight()
+                              + "&patient=p0",
+                          1,
+                          10))));
+    }
+  }
+
+  @Test
+  public void searchByPatientAndTwoCategoriesAndTwoDatesNoHack() {
+    /*
+    Observation dates for p0
+     2005-01-10T07:57:00Z -> laboratory
+     2005-01-12T07:57:00Z -> laboratory
+     2005-01-14T07:57:00Z -> laboratory
+     2005-01-16T07:57:00Z -> vital-signs
+     2005-01-18T07:57:00Z -> vital-signs
+
+    Observation dates for p1
+     2005-01-11T07:57:00Z -> laboratory
+     2005-01-13T07:57:00Z -> laboratory
+     2005-01-15T07:57:00Z -> vital-signs
+     2005-01-17T07:57:00Z -> vital-signs
+     2005-01-19T07:57:00Z -> vital-signs
+    */
+    Multimap<String, Observation> observationsByPatient = populateData();
+    /*
+    <criteria, expected dates>
+    key: search criteria (prefix + date)
+    value: expected date responses
+     */
+    Multimap<Pair<String, String>, String> testDates = LinkedHashMultimap.create();
+    testDates.putAll(
+        Pair.of("gt2004", "lt2006"),
+        List.of(
+            "2005-01-10T07:57:00Z",
+            "2005-01-12T07:57:00Z",
+            "2005-01-14T07:57:00Z",
+            "2005-01-16T07:57:00Z",
+            "2005-01-18T07:57:00Z"));
+    testDates.putAll(
+        Pair.of("gt2005-01-13", "lt2005-01-17"),
+        List.of("2005-01-14T07:57:00Z", "2005-01-16T07:57:00Z"));
+    for (var date : testDates.keySet()) {
+      List<Observation> observations =
+          observationsByPatient.get("p0").stream()
+              .filter(o -> testDates.get(date).contains(o.effectiveDateTime()))
+              .collect(Collectors.toList());
+      assertThat(
+              json(
+                  controller()
+                      .searchByPatientAndCategory(
+                          false,
                           "p0",
                           "laboratory,vital-signs",
                           new String[] {date.getLeft(), date.getRight()},

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/observation/ObservationSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/observation/ObservationSamples.java
@@ -313,8 +313,7 @@ public class ObservationSamples {
           .total(totalRecords)
           .link(Arrays.asList(links))
           .entry(
-              observations
-                  .stream()
+              observations.stream()
                   .map(
                       c ->
                           Entry.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/organization/OrganizationSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/organization/OrganizationSamples.java
@@ -82,8 +82,7 @@ public class OrganizationSamples {
           .total(organizations.size())
           .link(Arrays.asList(links))
           .entry(
-              organizations
-                  .stream()
+              organizations.stream()
                   .map(
                       c ->
                           gov.va.api.health.dstu2.api.resources.Organization.Entry.builder()
@@ -175,8 +174,7 @@ public class OrganizationSamples {
           .total(organizations.size())
           .link(Arrays.asList(links))
           .entry(
-              organizations
-                  .stream()
+              organizations.stream()
                   .map(
                       c ->
                           gov.va.api.health.stu3.api.resources.Organization.Entry.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/PatientSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/PatientSamples.java
@@ -81,8 +81,7 @@ public class PatientSamples {
           .total(records.size())
           .link(asList(links))
           .entry(
-              records
-                  .stream()
+              records.stream()
                   .map(
                       c ->
                           Patient.Entry.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/PractitionerSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/PractitionerSamples.java
@@ -84,8 +84,7 @@ public class PractitionerSamples {
           .total(practitioners.size())
           .link(asList(links))
           .entry(
-              practitioners
-                  .stream()
+              practitioners.stream()
                   .map(
                       c ->
                           gov.va.api.health.dstu2.api.resources.Practitioner.Entry.builder()
@@ -191,8 +190,7 @@ public class PractitionerSamples {
           .total(practitioners.size())
           .link(asList(links))
           .entry(
-              practitioners
-                  .stream()
+              practitioners.stream()
                   .map(
                       c ->
                           gov.va.api.health.stu3.api.resources.Practitioner.Entry.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitionerrole/PractitionerRoleSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitionerrole/PractitionerRoleSamples.java
@@ -149,8 +149,7 @@ public class PractitionerRoleSamples {
           .total(roles.size())
           .link(asList(links))
           .entry(
-              roles
-                  .stream()
+              roles.stream()
                   .map(
                       c ->
                           PractitionerRole.Entry.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/procedure/Dstu2ProcedureControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/procedure/Dstu2ProcedureControllerTest.java
@@ -325,9 +325,7 @@ public class Dstu2ProcedureControllerTest {
     testDates.putAll("sa2005-01-14", List.of("2005-01-16T07:57:00Z", "2005-01-18T07:57:00Z"));
     for (var date : testDates.keySet()) {
       List<Procedure> resources =
-          procedureByPatient
-              .get("p0")
-              .stream()
+          procedureByPatient.get("p0").stream()
               .filter(p -> testDates.get(date).contains(p.performedDateTime()))
               .collect(Collectors.toList());
       assertThat(json(controller().searchByPatientAndDate("p0", new String[] {date}, 1, 10)))
@@ -380,9 +378,7 @@ public class Dstu2ProcedureControllerTest {
     testDates.putAll(Pair.of("gt2005-01-13", "lt2005-01-15"), List.of("2005-01-14T07:57:00Z"));
     for (var date : testDates.keySet()) {
       List<Procedure> resources =
-          procedureByPatient
-              .get("p0")
-              .stream()
+          procedureByPatient.get("p0").stream()
               .filter(p -> testDates.get(date).contains(p.performedDateTime()))
               .collect(Collectors.toList());
       assertThat(

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/procedure/ProcedureSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/procedure/ProcedureSamples.java
@@ -79,8 +79,7 @@ public class ProcedureSamples {
           .total(totalRecords)
           .link(Arrays.asList(links))
           .entry(
-              resources
-                  .stream()
+              resources.stream()
                   .map(
                       c ->
                           Entry.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/FhirToDatamart.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/FhirToDatamart.java
@@ -124,9 +124,7 @@ public class FhirToDatamart {
             new F2DAllergyIntoleranceTransformer(fauxIds);
         AllergyIntolerance.Bundle allergyIntolerances =
             mapper.readValue(file, AllergyIntolerance.Bundle.class);
-        allergyIntolerances
-            .entry()
-            .stream()
+        allergyIntolerances.entry().stream()
             .map(AbstractEntry::resource)
             .map(allergyIntoleranceTransformer::fhirToDatamart)
             .forEach(a -> dmObjectToFile("AllInt" + a.cdwId() + ".json", a));
@@ -134,9 +132,7 @@ public class FhirToDatamart {
       case "Condition":
         F2DConditionTransformer conditionTransformer = new F2DConditionTransformer(fauxIds);
         Condition.Bundle conditions = mapper.readValue(file, Condition.Bundle.class);
-        conditions
-            .entry()
-            .stream()
+        conditions.entry().stream()
             .map(AbstractEntry::resource)
             .map(conditionTransformer::fhirToDatamart)
             .forEach(c -> dmObjectToFile("Con" + c.cdwId() + ".json", c));
@@ -146,9 +142,7 @@ public class FhirToDatamart {
             new F2DDiagnosticReportTransformer(fauxIds);
         DiagnosticReport.Bundle diagnosticReports =
             mapper.readValue(file, DiagnosticReport.Bundle.class);
-        diagnosticReports
-            .entry()
-            .stream()
+        diagnosticReports.entry().stream()
             .map(AbstractEntry::resource)
             .map(diagnosticReportTransformer::fhirToDatamart)
             .forEach(d -> dmObjectToFile("DiaRep" + d.reports().get(0).identifier() + ".json", d));
@@ -157,9 +151,7 @@ public class FhirToDatamart {
         F2DImmunizationTransformer immunizationTransformer =
             new F2DImmunizationTransformer(fauxIds);
         Immunization.Bundle immunizations = mapper.readValue(file, Immunization.Bundle.class);
-        immunizations
-            .entry()
-            .stream()
+        immunizations.entry().stream()
             .map(AbstractEntry::resource)
             .map(immunizationTransformer::fhirToDatamart)
             .forEach(i -> dmObjectToFile("Imm" + i.cdwId() + ".json", i));
@@ -175,9 +167,7 @@ public class FhirToDatamart {
             new F2DMedicationOrderTransformer(fauxIds);
         MedicationOrder.Bundle medicationOrders =
             mapper.readValue(file, MedicationOrder.Bundle.class);
-        medicationOrders
-            .entry()
-            .stream()
+        medicationOrders.entry().stream()
             .map(AbstractEntry::resource)
             .map(medicationOrderTransformer::fhirToDatamart)
             .forEach(mo -> dmObjectToFile("MedOrd" + mo.cdwId() + ".json", mo));
@@ -187,9 +177,7 @@ public class FhirToDatamart {
             new F2DMedicationStatementTransformer(fauxIds);
         MedicationStatement.Bundle medicationStatements =
             mapper.readValue(file, MedicationStatement.Bundle.class);
-        medicationStatements
-            .entry()
-            .stream()
+        medicationStatements.entry().stream()
             .map(AbstractEntry::resource)
             .map(medicationStatementTransformer::fhirToDatamart)
             .forEach(ms -> dmObjectToFile("MedSta" + ms.cdwId() + ".json", ms));
@@ -197,9 +185,7 @@ public class FhirToDatamart {
       case "Observation":
         F2DObservationTransformer observationTransformer = new F2DObservationTransformer(fauxIds);
         Observation.Bundle observations = mapper.readValue(file, Observation.Bundle.class);
-        observations
-            .entry()
-            .stream()
+        observations.entry().stream()
             .map(AbstractEntry::resource)
             .map(observationTransformer::fhirToDatamart)
             .forEach(o -> dmObjectToFile("Obs" + o.cdwId() + ".json", o));
@@ -207,9 +193,7 @@ public class FhirToDatamart {
       case "Patient":
         F2DPatientTransformer patientTransformer = new F2DPatientTransformer(fauxIds);
         Patient.Bundle patients = mapper.readValue(file, Patient.Bundle.class);
-        patients
-            .entry()
-            .stream()
+        patients.entry().stream()
             .map(AbstractEntry::resource)
             .map(patientTransformer::fhirToDatamart)
             .forEach(p -> dmObjectToFile("Pat" + p.fullIcn() + ".json", p));
@@ -217,9 +201,7 @@ public class FhirToDatamart {
       case "Procedure":
         F2DProcedureTransformer procedureTransformer = new F2DProcedureTransformer(fauxIds);
         Procedure.Bundle procedures = mapper.readValue(file, Procedure.Bundle.class);
-        procedures
-            .entry()
-            .stream()
+        procedures.entry().stream()
             .map(AbstractEntry::resource)
             .map(procedureTransformer::fhirToDatamart)
             .forEach(pr -> dmObjectToFile("Pro" + pr.cdwId() + ".json", pr));

--- a/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DAllergyIntoleranceTransformer.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DAllergyIntoleranceTransformer.java
@@ -49,8 +49,7 @@ public class F2DAllergyIntoleranceTransformer {
     if (codings == null || codings.isEmpty()) {
       return null;
     }
-    return codings
-        .stream()
+    return codings.stream()
         .map(c -> coding(c))
         .filter(Optional::isPresent)
         .map(c -> c.get())
@@ -81,8 +80,7 @@ public class F2DAllergyIntoleranceTransformer {
   }
 
   private List<DatamartCoding> manifestations(List<CodeableConcept> manifestations) {
-    return manifestations
-        .stream()
+    return manifestations.stream()
         .map(CodeableConcept::coding)
         .flatMap(codings -> codings(codings).stream())
         .collect(Collectors.toList());

--- a/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DConditionTransformer.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DConditionTransformer.java
@@ -69,8 +69,7 @@ public class F2DConditionTransformer {
     if (code == null) {
       return null;
     }
-    return code.coding()
-        .stream()
+    return code.coding().stream()
         .filter(coding -> whichCode(coding) == CodeSystem.ICD)
         .map(
             coding ->
@@ -86,8 +85,7 @@ public class F2DConditionTransformer {
     if (code == null) {
       return null;
     }
-    return code.coding()
-        .stream()
+    return code.coding().stream()
         .filter(coding -> whichCode(coding) == CodeSystem.SNOMED)
         .map(coding -> SnomedCode.builder().code(coding.code()).display(coding.display()).build())
         .findFirst();

--- a/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DDiagnosticReportTransformer.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DDiagnosticReportTransformer.java
@@ -50,8 +50,7 @@ public class F2DDiagnosticReportTransformer {
     if (results == null || results.isEmpty()) {
       return null;
     }
-    return results
-        .stream()
+    return results.stream()
         .map(
             r ->
                 DatamartDiagnosticReports.Result.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DMedicationOrderTransformer.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DMedicationOrderTransformer.java
@@ -104,8 +104,7 @@ public class F2DMedicationOrderTransformer {
     if (dosageInstructions.isEmpty()) {
       return null;
     }
-    return dosageInstructions
-        .stream()
+    return dosageInstructions.stream()
         .map(
             dosageInstruction ->
                 DosageInstruction.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DObservationTransformer.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DObservationTransformer.java
@@ -129,22 +129,19 @@ public class F2DObservationTransformer {
       return obsBuilder.build();
     }
     List<DatamartObservation.AntibioticComponent> ac =
-        component
-            .stream()
+        component.stream()
             .filter(c -> c != null && c.id() != null)
             .map(c -> antibioticComponent(c))
             .filter(a -> a != null)
             .collect(Collectors.toList());
     List<DatamartObservation.VitalsComponent> vc =
-        component
-            .stream()
+        component.stream()
             .filter(c -> c != null && c.valueQuantity() != null)
             .map(c -> vitalsComponent(c))
             .filter(v -> v != null)
             .collect(Collectors.toList());
     List<Optional<DatamartObservation.BacteriologyComponent>> bc =
-        component
-            .stream()
+        component.stream()
             .filter(c -> c != null && c.valueString() != null)
             .map(c -> bacteriologyComponent(c))
             .filter(b -> b != null)
@@ -195,8 +192,7 @@ public class F2DObservationTransformer {
     if (performer == null || performer.isEmpty()) {
       return null;
     }
-    return performer
-        .stream()
+    return performer.stream()
         .filter(x -> x != null)
         .map(p -> fauxIds.toDatamartReferenceWithCdwId(p))
         .filter(x -> x.isPresent())

--- a/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DPatientTransformer.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/tools/minimart/transformers/F2DPatientTransformer.java
@@ -277,8 +277,7 @@ public class F2DPatientTransformer {
     if (races == null || races.isEmpty()) {
       return null;
     }
-    return races
-        .stream()
+    return races.stream()
         .filter(x -> x != null)
         .map(Extension::valueCoding)
         .filter(x -> x != null)

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>health-apis-parent</artifactId>
-    <version>4.0.6</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>data-query-parent</artifactId>
   <version>2.0.227-SNAPSHOT</version>

--- a/src/scripts/dev-app.sh
+++ b/src/scripts/dev-app.sh
@@ -47,7 +47,7 @@ startApp() {
     local pathSeparator=':'
     [ "$(uname)" != "Darwin" ] && [ "$(uname)" != "Linux" ] && echo "Add support for your operating system" && exit 1
     echo "Using local H2 database"
-    options+=" -cp $(readlink -f $jar)${pathSeparator}$(readlink -f ~/.m2/repository/com/h2database/h2/1.4.197/h2-1.4.197.jar)"
+    options+=" -cp $(readlink -f $jar)${pathSeparator}$(readlink -f ~/.m2/repository/com/h2database/h2/1.4.200/h2-1.4.200.jar)"
     options+=" -Dspring.jpa.generate-ddl=true"
     options+=" -Dspring.jpa.hibernate.ddl-auto=create-drop"
     options+=" -Dspring.jpa.hibernate.globally_quoted_identifiers=true"


### PR DESCRIPTION
Alters behavior of `Observation.searchByPatientAndCategory` to select _all_ records and paginate in application code per Andrew Kelly's recommendation since SQL Server is performing a full table scan when paging criteria is part of the query.

This solution makes me sad.

It is enabled by default, but can be disabled per request with HTTP request header `query-hack:false`