### PR TITLE
SHANK-301 Validate FHIR responses

### DIFF
--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/ValidationAdvice.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/ValidationAdvice.java
@@ -31,11 +31,7 @@ public final class ValidationAdvice implements ResponseBodyAdvice<Object> {
       ServletServerHttpRequest servletRequest = (ServletServerHttpRequest) request;
       sb.append("(")
           .append(
-              servletRequest
-                  .getServletRequest()
-                  .getParameterMap()
-                  .entrySet()
-                  .stream()
+              servletRequest.getServletRequest().getParameterMap().entrySet().stream()
                   .map(e -> e.getKey() + "=" + Arrays.toString(e.getValue()))
                   .collect(Collectors.joining(",")))
           .append(")");
@@ -45,8 +41,7 @@ public final class ValidationAdvice implements ResponseBodyAdvice<Object> {
         .append(payload.getClass().getName())
         .append(" failed validation: ")
         .append(
-            violations
-                .stream()
+            violations.stream()
                 .sorted(
                     (left, right) ->
                         left.getPropertyPath()

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/ValidationAdvice.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/ValidationAdvice.java
@@ -1,0 +1,65 @@
+package gov.va.api.health.dataquery.service.controller;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@Slf4j
+@ControllerAdvice
+public final class ValidationAdvice implements ResponseBodyAdvice<Object> {
+  @Override
+  public Object beforeBodyWrite(
+      Object payload,
+      MethodParameter method,
+      MediaType unused1,
+      Class<? extends HttpMessageConverter<?>> unused2,
+      ServerHttpRequest request,
+      ServerHttpResponse unused3) {
+    Set<ConstraintViolation<Object>> violations =
+        Validation.buildDefaultValidatorFactory().getValidator().validate(payload);
+    if (violations.isEmpty()) {
+      return payload;
+    }
+
+    StringBuilder sb = new StringBuilder().append(method.getExecutable().getName());
+
+    if (request instanceof ServletServerHttpRequest) {
+      ServletServerHttpRequest servletRequest = (ServletServerHttpRequest) request;
+      sb.append("(")
+          .append(
+              servletRequest.getServletRequest().getParameterMap().entrySet().stream()
+                  .map(e -> e.getKey() + "=" + Arrays.toString(e.getValue()))
+                  .collect(Collectors.joining(",")))
+          .append(")");
+    }
+
+    sb.append(" response ")
+        .append(payload.getClass().getName())
+        .append(" failed validation: ")
+        .append(
+            violations.stream()
+                .map(v -> v.getPropertyPath() + " " + v.getMessage())
+                .collect(Collectors.joining(", ")));
+
+    log.warn(sb.toString());
+
+    return payload;
+  }
+
+  @Override
+  public boolean supports(
+      MethodParameter methodParameter, Class<? extends HttpMessageConverter<?>> unused) {
+    return true;
+  }
+}

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/ValidationAdviceTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/ValidationAdviceTest.java
@@ -34,6 +34,11 @@ public class ValidationAdviceTest {
                 + "bar must not be null, foo must not be blank, num must be greater than or equal to 1");
   }
 
+  @Test
+  public void noViolations() {
+    assertThat(ValidationAdvice.buildMessage("x", null, null)).isNull();
+  }
+
   private static final class Controller {
     @SuppressWarnings("unused")
     Foo read(String unused) {

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/ValidationAdviceTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/ValidationAdviceTest.java
@@ -1,0 +1,52 @@
+package gov.va.api.health.dataquery.service.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.SneakyThrows;
+import org.junit.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.server.ServletServerHttpRequest;
+
+public class ValidationAdviceTest {
+  @Test
+  @SneakyThrows
+  public void message() {
+    HttpServletRequest servletRequest = mock(HttpServletRequest.class);
+    when(servletRequest.getParameterMap())
+        .thenReturn(ImmutableMap.of("v", new String[] {"w", "x"}, "y", new String[] {"z"}));
+
+    ServletServerHttpRequest servletServerRequest = mock(ServletServerHttpRequest.class);
+    when(servletServerRequest.getServletRequest()).thenReturn(servletRequest);
+
+    MethodParameter method =
+        new MethodParameter(Controller.class.getDeclaredMethod("read", String.class), -1);
+
+    assertThat(ValidationAdvice.buildMessage(new Foo(), method, servletServerRequest))
+        .isEqualTo(
+            "read(v=[w, x],y=[z]) response gov.va.api.health.dataquery.service.controller.ValidationAdviceTest$Foo failed validation: "
+                + "bar must not be null, foo must not be blank, num must be greater than or equal to 1");
+  }
+
+  private static final class Controller {
+    @SuppressWarnings("unused")
+    Foo read(String unused) {
+      return new Foo();
+    }
+  }
+
+  private static final class Foo {
+    @NotBlank String foo;
+
+    @NotNull String bar;
+
+    @Min(1)
+    int num;
+  }
+}


### PR DESCRIPTION
https://vasdvp.atlassian.net/browse/SHANK-301

Example messages:
```
WARN 21648 --- [nio-8090-exec-3] g.v.a.h.d.s.controller.ValidationAdvice  : read() response gov.va.api.health.stu3.api.resources.Practitioner failed validation: resourceType must not be blank, name.family must not be null, id must match "[A-Za-z0-9\-\.]{1,64}"

WARN 21648 --- [nio-8090-exec-2] g.v.a.h.d.s.controller.ValidationAdvice  : searchById(_id=[416704]) response gov.va.api.health.stu3.api.resources.Practitioner$Bundle failed validation: entry[0].resource.name.family must not be null, entry[0].resource.resourceType must not be blank, entry[0].resource.id must match "[A-Za-z0-9\-\.]{1,64}"
```