### PR TITLE
patient v2 with feature toggle

### DIFF
--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/PatientIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/PatientIT.java
@@ -49,12 +49,11 @@ public class PatientIT {
             Patient.Bundle.class,
             "Patient?name={name}&gender={gender}",
             verifier.ids().pii().name(),
-            verifier
-                .ids()
-                .pii()
-                .gender()), // These are tests for the UnsatisfiedServletRequestParameterException
-        // mapping to bad
-        // request.
+            verifier.ids().pii().gender()),
+        /**
+         * These are tests for the UnsatisfiedServletRequestParameterException mapping to bad
+         * request.
+         */
         test(400, OperationOutcome.class, "Patient?given={given}", verifier.ids().pii().given()),
         test(400, OperationOutcome.class, "Patient/"));
   }

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/PatientIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/PatientIT.java
@@ -114,7 +114,7 @@ public class PatientIT {
         TestClients.dstu2DataQuery()
             .service()
             .requestSpecification()
-            .header(new Header("patientV2", "true"))
+            .header(new Header("patientV2", "false"))
             .request(
                 Method.GET,
                 TestClients.dstu2DataQuery().service().urlWithApiPath()
@@ -126,7 +126,7 @@ public class PatientIT {
         TestClients.dstu2DataQuery()
             .service()
             .requestSpecification()
-            .header(new Header("patientV2", "false"))
+            .header(new Header("patientV2", "true"))
             .request(
                 Method.GET,
                 TestClients.dstu2DataQuery().service().urlWithApiPath()
@@ -154,7 +154,7 @@ public class PatientIT {
         TestClients.dstu2DataQuery()
             .service()
             .requestSpecification()
-            .header(new Header("patientV2", "true"))
+            .header(new Header("patientV2", "false"))
             .request(
                 Method.GET,
                 TestClients.dstu2DataQuery().service().urlWithApiPath()
@@ -168,7 +168,7 @@ public class PatientIT {
         TestClients.dstu2DataQuery()
             .service()
             .requestSpecification()
-            .header(new Header("patientV2", "false"))
+            .header(new Header("patientV2", "true"))
             .request(
                 Method.GET,
                 TestClients.dstu2DataQuery().service().urlWithApiPath()

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/PatientIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/PatientIT.java
@@ -1,7 +1,10 @@
 package gov.va.api.health.dataquery.tests.dstu2;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import gov.va.api.health.argonaut.api.resources.Patient;
 import gov.va.api.health.dataquery.tests.ResourceVerifier;
+import gov.va.api.health.dataquery.tests.TestClients;
 import gov.va.api.health.dataquery.tests.categories.LabDataQueryClinician;
 import gov.va.api.health.dataquery.tests.categories.LabDataQueryPatient;
 import gov.va.api.health.dataquery.tests.categories.ProdDataQueryClinician;
@@ -10,6 +13,8 @@ import gov.va.api.health.dstu2.api.resources.OperationOutcome;
 import gov.va.api.health.sentinel.Environment;
 import gov.va.api.health.sentinel.categories.Local;
 import gov.va.api.health.sentinel.categories.Smoke;
+import io.restassured.http.Header;
+import io.restassured.http.Method;
 import lombok.experimental.Delegate;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -44,8 +49,11 @@ public class PatientIT {
             Patient.Bundle.class,
             "Patient?name={name}&gender={gender}",
             verifier.ids().pii().name(),
-            verifier.ids().pii().gender()),
-        // These are tests for the UnsatisfiedServletRequestParameterException mapping to bad
+            verifier
+                .ids()
+                .pii()
+                .gender()), // These are tests for the UnsatisfiedServletRequestParameterException
+        // mapping to bad
         // request.
         test(400, OperationOutcome.class, "Patient?given={given}", verifier.ids().pii().given()),
         test(400, OperationOutcome.class, "Patient/"));
@@ -94,5 +102,45 @@ public class PatientIT {
     verifier.verifyAll(
         test(status, OperationOutcome.class, "Patient/{id}", verifier.ids().unknown()),
         test(status, OperationOutcome.class, "Patient?_id={id}", verifier.ids().unknown()));
+  }
+
+  /**
+   * Temporary equality validation while we support backwards compatibility of patient v1 and v2.
+   */
+  @Test
+  @Category({
+    Local.class,
+    Smoke.class,
+    LabDataQueryPatient.class,
+    LabDataQueryClinician.class,
+    ProdDataQueryPatient.class,
+    ProdDataQueryClinician.class
+  })
+  public void patientV1EqualsV2() {
+    var patientV1 =
+        TestClients.dstu2DataQuery()
+            .service()
+            .requestSpecification()
+            .header(new Header("patientV2", "true"))
+            .request(
+                Method.GET,
+                TestClients.dstu2DataQuery().service().urlWithApiPath()
+                    + "Patient/"
+                    + verifier.ids().patient())
+            .getBody()
+            .asString();
+    var patientV2 =
+        TestClients.dstu2DataQuery()
+            .service()
+            .requestSpecification()
+            .header(new Header("patientV2", ""))
+            .request(
+                Method.GET,
+                TestClients.dstu2DataQuery().service().urlWithApiPath()
+                    + "Patient/"
+                    + verifier.ids().patient())
+            .getBody()
+            .asString();
+    assertThat(patientV1).isEqualTo(patientV2);
   }
 }

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/PatientIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/PatientIT.java
@@ -50,7 +50,7 @@ public class PatientIT {
             "Patient?name={name}&gender={gender}",
             verifier.ids().pii().name(),
             verifier.ids().pii().gender()),
-        /**
+        /*
          * These are tests for the UnsatisfiedServletRequestParameterException mapping to bad
          * request.
          */

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/PatientIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/PatientIT.java
@@ -108,15 +108,8 @@ public class PatientIT {
    * Temporary equality validation while we support backwards compatibility of patient v1 and v2.
    */
   @Test
-  @Category({
-    Local.class,
-    Smoke.class,
-    LabDataQueryPatient.class,
-    LabDataQueryClinician.class,
-    ProdDataQueryPatient.class,
-    ProdDataQueryClinician.class
-  })
-  public void patientV1EqualsV2() {
+  @Category({Local.class, LabDataQueryClinician.class, ProdDataQueryClinician.class})
+  public void patientV1EqualsV2Read() {
     var patientV1 =
         TestClients.dstu2DataQuery()
             .service()
@@ -133,12 +126,56 @@ public class PatientIT {
         TestClients.dstu2DataQuery()
             .service()
             .requestSpecification()
-            .header(new Header("patientV2", ""))
+            .header(new Header("patientV2", "false"))
             .request(
                 Method.GET,
                 TestClients.dstu2DataQuery().service().urlWithApiPath()
                     + "Patient/"
                     + verifier.ids().patient())
+            .getBody()
+            .asString();
+    assertThat(patientV1).isEqualTo(patientV2);
+  }
+
+  /**
+   * Temporary equality validation while we support backwards compatibility of patient v1 and v2.
+   */
+  @Test
+  @Category({
+    Local.class,
+    Smoke.class,
+    LabDataQueryPatient.class,
+    LabDataQueryClinician.class,
+    ProdDataQueryPatient.class,
+    ProdDataQueryClinician.class
+  })
+  public void patientV1EqualsV2SearchByNameAndGender() {
+    var patientV1 =
+        TestClients.dstu2DataQuery()
+            .service()
+            .requestSpecification()
+            .header(new Header("patientV2", "true"))
+            .request(
+                Method.GET,
+                TestClients.dstu2DataQuery().service().urlWithApiPath()
+                    + "Patient?given="
+                    + verifier.ids().pii().given()
+                    + "&gender="
+                    + verifier.ids().pii().gender())
+            .getBody()
+            .asString();
+    var patientV2 =
+        TestClients.dstu2DataQuery()
+            .service()
+            .requestSpecification()
+            .header(new Header("patientV2", "false"))
+            .request(
+                Method.GET,
+                TestClients.dstu2DataQuery().service().urlWithApiPath()
+                    + "Patient?given="
+                    + verifier.ids().pii().given()
+                    + "&gender="
+                    + verifier.ids().pii().gender())
             .getBody()
             .asString();
     assertThat(patientV1).isEqualTo(patientV2);

--- a/data-query/spotbugs-excludes.xml
+++ b/data-query/spotbugs-excludes.xml
@@ -60,6 +60,7 @@
     <Or>
       <Class name="gov.va.api.health.dataquery.service.controller.observation.ObservationRepository$PatientAndCategoryAndDateSpecification$PatientAndCategoryAndDateSpecificationBuilder"/>
       <Class name="gov.va.api.health.dataquery.service.controller.patient.PatientSearchRepository$NameAndBirthdateSpecification$NameAndBirthdateSpecificationBuilder"/>
+      <Class name="gov.va.api.health.dataquery.service.controller.patient.PatientRepositoryV2$NameAndBirthdateSpecification$NameAndBirthdateSpecificationBuilder"/>
       <Class name="gov.va.api.health.dataquery.service.controller.procedure.ProcedureRepository$PatientAndDateSpecification$PatientAndDateSpecificationBuilder"/>
     </Or>
     <Bug pattern="EI_EXPOSE_REP2"/>

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/Dstu2PatientController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/Dstu2PatientController.java
@@ -49,7 +49,7 @@ import org.springframework.web.bind.annotation.RestController;
     value = {"/dstu2/Patient"},
     produces = {"application/json", "application/json+fhir", "application/fhir+json"})
 public class Dstu2PatientController {
-  PatientV2 patientV2 = new PatientV2();
+  private final PatientV2 patientV2 = new PatientV2();
 
   private boolean defaultPatientV2;
 

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/PatientRepositoryV2.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/PatientRepositoryV2.java
@@ -1,14 +1,65 @@
 package gov.va.api.health.dataquery.service.controller.patient;
 
 import gov.va.api.health.autoconfig.logging.Loggable;
+import gov.va.api.health.dataquery.service.controller.DateTimeParameters;
+import java.util.ArrayList;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import lombok.Builder;
+import lombok.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Loggable
 @Transactional(isolation = Isolation.READ_UNCOMMITTED)
-public interface PatientRepositoryV2 extends PagingAndSortingRepository<PatientEntityV2, String> {
+public interface PatientRepositoryV2
+    extends PagingAndSortingRepository<PatientEntityV2, String>,
+        JpaSpecificationExecutor<PatientEntityV2> {
+  Page<PatientEntityV2> findByFirstNameAndGender(
+      String firstName, String gender, Pageable pageable);
+
+  Page<PatientEntityV2> findByFullNameAndGender(String name, String gender, Pageable pageable);
+
   Page<PatientEntityV2> findByIcn(String icn, Pageable pageable);
+
+  Page<PatientEntityV2> findByLastNameAndGender(String lastName, String gender, Pageable pageable);
+
+  @Value
+  class NameAndBirthdateSpecification implements Specification<PatientEntityV2> {
+    String name;
+
+    DateTimeParameters date1;
+
+    DateTimeParameters date2;
+
+    @Builder
+    private NameAndBirthdateSpecification(String name, String[] dates) {
+      this.name = name;
+      date1 = (dates == null || dates.length < 1) ? null : new DateTimeParameters(dates[0]);
+      date2 = (dates == null || dates.length < 2) ? null : new DateTimeParameters(dates[1]);
+    }
+
+    @Override
+    public Predicate toPredicate(
+        Root<PatientEntityV2> root,
+        CriteriaQuery<?> criteriaQuery,
+        CriteriaBuilder criteriaBuilder) {
+      var predicates = new ArrayList<>(3);
+      predicates.add(criteriaBuilder.equal(root.get("fullName"), name()));
+      if (date1() != null) {
+        predicates.add(date1().toInstantPredicate(root.get("birthDate"), criteriaBuilder));
+      }
+      if (date2() != null) {
+        predicates.add(date2().toInstantPredicate(root.get("birthDate"), criteriaBuilder));
+      }
+      return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+    }
+  }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/PatientRepositoryV2.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/PatientRepositoryV2.java
@@ -1,0 +1,14 @@
+package gov.va.api.health.dataquery.service.controller.patient;
+
+import gov.va.api.health.autoconfig.logging.Loggable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Loggable
+@Transactional(isolation = Isolation.READ_UNCOMMITTED)
+public interface PatientRepositoryV2 extends PagingAndSortingRepository<PatientEntityV2, String> {
+  Page<PatientEntityV2> findByIcn(String icn, Pageable pageable);
+}

--- a/data-query/src/main/resources/application.properties
+++ b/data-query/src/main/resources/application.properties
@@ -41,6 +41,7 @@ conformance.resourceDocumentation=Implemented per specification. See http://hl7.
 included-references.location=true
 included-references.organization=true
 included-references.practitioner=true
+default.patientV2=false
 
 spring.datasource.driver-class-name=com.microsoft.sqlserver.jdbc.SQLServerDriver
 spring.datasource.password=unset

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/WebExceptionHandlerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/WebExceptionHandlerTest.java
@@ -80,7 +80,8 @@ public class WebExceptionHandlerTest {
   @Before
   public void _init() {
     MockitoAnnotations.initMocks(this);
-    controller = new Dstu2PatientController(bundler, repository, repositoryV2, witnessProtection);
+    controller =
+        new Dstu2PatientController(false, bundler, repository, repositoryV2, witnessProtection);
     exceptionHandler = new WebExceptionHandler("1234567890123456");
   }
 

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/WebExceptionHandlerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/WebExceptionHandlerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.JsonMappingException;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
 import gov.va.api.health.dataquery.service.controller.patient.Dstu2PatientController;
+import gov.va.api.health.dataquery.service.controller.patient.PatientRepositoryV2;
 import gov.va.api.health.dataquery.service.controller.patient.PatientSearchRepository;
 import gov.va.api.health.ids.client.IdEncoder.BadId;
 import java.lang.reflect.Method;
@@ -52,6 +53,7 @@ public class WebExceptionHandlerTest {
   @Mock HttpServletRequest request;
   @Mock Dstu2Bundler bundler;
   @Mock PatientSearchRepository repository;
+  @Mock PatientRepositoryV2 repositoryV2;
   @Mock WitnessProtection witnessProtection;
   private Dstu2PatientController controller;
   private WebExceptionHandler exceptionHandler;
@@ -78,7 +80,7 @@ public class WebExceptionHandlerTest {
   @Before
   public void _init() {
     MockitoAnnotations.initMocks(this);
-    controller = new Dstu2PatientController(bundler, repository, witnessProtection);
+    controller = new Dstu2PatientController(bundler, repository, repositoryV2, witnessProtection);
     exceptionHandler = new WebExceptionHandler("1234567890123456");
   }
 

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/DatamartPatientTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/DatamartPatientTest.java
@@ -47,6 +47,8 @@ public final class DatamartPatientTest {
 
   @Autowired private PatientSearchRepository repository;
 
+  @Autowired private PatientRepositoryV2 repositoryV2;
+
   @Before
   public void _init() {
     response = mock(HttpServletResponse.class);
@@ -65,7 +67,7 @@ public final class DatamartPatientTest {
     entityManager.persistAndFlush(dm.entity());
     entityManager.persistAndFlush(dm.search());
     Dstu2PatientController controller = controller();
-    Patient patient = controller.read(dm.icn());
+    Patient patient = controller.read(false, dm.icn());
     assertThat(json(patient)).isEqualTo(json(fhir.patient()));
   }
 
@@ -146,6 +148,7 @@ public final class DatamartPatientTest {
     return new Dstu2PatientController(
         new Dstu2Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool", "cool")),
         repository,
+        repositoryV2,
         WitnessProtection.builder().identityService(mock(IdentityService.class)).build());
   }
 
@@ -175,7 +178,7 @@ public final class DatamartPatientTest {
     PatientSearchEntity search = PatientSearchEntity.builder().icn(icn).patient(entity).build();
     entityManager.persistAndFlush(search);
     Dstu2PatientController controller = controller();
-    Patient patient = controller.read(icn);
+    Patient patient = controller.read(false, icn);
     assertThat(patient)
         .isEqualTo(
             Patient.builder()
@@ -473,7 +476,7 @@ public final class DatamartPatientTest {
     FhirData fhir = FhirData.from(dm);
     entityManager.persistAndFlush(dm.entity());
     entityManager.persistAndFlush(dm.search());
-    Patient.Bundle patient = controller().searchById("1011537977V693883", 1, 1);
+    Patient.Bundle patient = controller().searchById(false, "1011537977V693883", 1, 1);
     assertThat(json(Iterables.getOnlyElement(patient.entry()).resource()))
         .isEqualTo(json(fhir.patient()));
   }
@@ -484,7 +487,7 @@ public final class DatamartPatientTest {
     FhirData fhir = FhirData.from(dm);
     entityManager.persistAndFlush(dm.entity());
     entityManager.persistAndFlush(dm.search());
-    Patient.Bundle patient = controller().searchByIdentifier("1011537977V693883", 1, 1);
+    Patient.Bundle patient = controller().searchByIdentifier(false, "1011537977V693883", 1, 1);
     assertThat(json(Iterables.getOnlyElement(patient.entry()).resource()))
         .isEqualTo(json(fhir.patient()));
   }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/DatamartPatientTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/DatamartPatientTest.java
@@ -4,16 +4,10 @@ import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMap
 import static gov.va.api.health.dataquery.service.controller.Dstu2Transformers.parseInstant;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
-import com.google.common.collect.Iterables;
 import gov.va.api.health.argonaut.api.resources.Patient;
 import gov.va.api.health.argonaut.api.resources.Patient.Gender;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.health.dataquery.service.controller.ConfigurableBaseUrlPageLinks;
-import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
-import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dstu2.api.datatypes.Address;
 import gov.va.api.health.dstu2.api.datatypes.CodeableConcept;
 import gov.va.api.health.dstu2.api.datatypes.Coding;
@@ -23,52 +17,23 @@ import gov.va.api.health.dstu2.api.datatypes.HumanName;
 import gov.va.api.health.dstu2.api.datatypes.Identifier;
 import gov.va.api.health.dstu2.api.elements.Extension;
 import gov.va.api.health.dstu2.api.elements.Reference;
-import gov.va.api.health.ids.api.IdentityService;
-import java.util.Collections;
 import java.util.Optional;
-import javax.servlet.http.HttpServletResponse;
 import lombok.Builder;
 import lombok.SneakyThrows;
 import lombok.Value;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @DataJpaTest
 @RunWith(SpringRunner.class)
 public final class DatamartPatientTest {
-  HttpServletResponse response;
-
-  @Autowired private TestEntityManager entityManager;
-
-  @Autowired private PatientSearchRepository repository;
-
-  @Autowired private PatientRepositoryV2 repositoryV2;
-
-  @Before
-  public void _init() {
-    response = mock(HttpServletResponse.class);
-  }
 
   @Test
   public void address() {
     assertThat(Dstu2PatientTransformer.address(DatamartPatient.Address.builder().build())).isNull();
     assertThat(Dstu2PatientTransformer.address(null)).isNull();
-  }
-
-  @Test
-  public void basic() {
-    DatamartData dm = DatamartData.create();
-    FhirData fhir = FhirData.from(dm);
-    entityManager.persistAndFlush(dm.entity());
-    entityManager.persistAndFlush(dm.search());
-    Dstu2PatientController controller = controller();
-    Patient patient = controller.read("false", dm.icn());
-    assertThat(json(patient)).isEqualTo(json(fhir.patient()));
   }
 
   Coding coding(String system, String code, String display) {
@@ -144,15 +109,6 @@ public final class DatamartPatientTest {
     assertThat(Dstu2PatientTransformer.contactTelecoms(null)).isNull();
   }
 
-  public Dstu2PatientController controller() {
-    return new Dstu2PatientController(
-        false,
-        new Dstu2Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool", "cool")),
-        repository,
-        repositoryV2,
-        WitnessProtection.builder().identityService(mock(IdentityService.class)).build());
-  }
-
   @Test
   public void deceased() {
     DatamartPatient unparseable = DatamartPatient.builder().deathDateTime("unparseable").build();
@@ -162,47 +118,6 @@ public final class DatamartPatientTest {
     DatamartPatient deceasedDt =
         DatamartPatient.builder().deathDateTime("2013-11-16T02:33:33").build();
     assertThat(tx(deceasedDt).deceasedDateTime()).isEqualTo("2013-11-16T02:33:33Z");
-  }
-
-  @Test
-  @SneakyThrows
-  public void empty() {
-    String icn = "1011537977V693883";
-    PatientEntity entity =
-        PatientEntity.builder()
-            .icn(icn)
-            .payload(
-                JacksonConfig.createMapper()
-                    .writeValueAsString(DatamartPatient.builder().fullIcn(icn).build()))
-            .build();
-    entityManager.persistAndFlush(entity);
-    PatientSearchEntity search = PatientSearchEntity.builder().icn(icn).patient(entity).build();
-    entityManager.persistAndFlush(search);
-    Dstu2PatientController controller = controller();
-    Patient patient = controller.read("false", icn);
-    assertThat(patient)
-        .isEqualTo(
-            Patient.builder()
-                .id(icn)
-                .resourceType("Patient")
-                .identifier(
-                    asList(
-                        Identifier.builder()
-                            .use(Identifier.IdentifierUse.usual)
-                            .type(
-                                CodeableConcept.builder()
-                                    .coding(
-                                        asList(
-                                            Coding.builder()
-                                                .system("http://hl7.org/fhir/v2/0203")
-                                                .code("MR")
-                                                .build()))
-                                    .build())
-                            .system("http://va.gov/mvi")
-                            .value(icn)
-                            .assigner(Reference.builder().display("Master Veteran Index").build())
-                            .build()))
-                .build());
   }
 
   @Test
@@ -386,18 +301,6 @@ public final class DatamartPatientTest {
   }
 
   @Test
-  public void readRaw() {
-    DatamartData dm = DatamartData.create();
-    PatientEntity entity = dm.entity();
-    entityManager.persistAndFlush(entity);
-    entityManager.persistAndFlush(dm.search());
-    String json = controller().readRaw(dm.icn(), response);
-    assertThat(PatientEntity.builder().payload(json).build().asDatamartPatient())
-        .isEqualTo(dm.patient());
-    verify(response).addHeader("X-VA-INCLUDES-ICN", entity.icn());
-  }
-
-  @Test
   public void relationshipCoding() {
     Coding.CodingBuilder cb =
         Coding.builder().system("http://hl7.org/fhir/patient-contact-relationship");
@@ -430,91 +333,6 @@ public final class DatamartPatientTest {
                 DatamartPatient.Contact.builder().type("SPOUSE EMPLOYER").build()))
         .isEqualTo(cb.code("family").display("Family").build());
     assertThat(Dstu2PatientTransformer.relationshipCoding(null)).isNull();
-  }
-
-  @Test
-  public void searchByFamilyAndGender() {
-    DatamartData dm = DatamartData.create();
-    FhirData fhir = FhirData.from(dm);
-    entityManager.persistAndFlush(dm.entity());
-    entityManager.persistAndFlush(dm.search());
-    Patient.Bundle patient = controller().searchByFamilyAndGender("TEST", "male", 1, 1);
-    assertThat(json(Iterables.getOnlyElement(patient.entry()).resource()))
-        .isEqualTo(json(fhir.patient()));
-  }
-
-  @Test
-  public void searchByFamilyAndGenderWithCountZero() {
-    DatamartData dm = DatamartData.create();
-    entityManager.persistAndFlush(dm.entity());
-    entityManager.persistAndFlush(dm.search());
-    Patient.Bundle patient = controller().searchByFamilyAndGender("TEST", "male", 1, 0);
-    assertThat(patient.entry()).isEqualTo(Collections.emptyList());
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void searchByFamilyAndGenderWithNullCdw() {
-    DatamartData dm = DatamartData.create();
-    entityManager.persistAndFlush(dm.entity());
-    entityManager.persistAndFlush(dm.search());
-    controller().searchByFamilyAndGender("TEST", "null", 1, 0);
-  }
-
-  @Test
-  public void searchByGivenAndGender() {
-    DatamartData dm = DatamartData.create();
-    FhirData fhir = FhirData.from(dm);
-    entityManager.persistAndFlush(dm.entity());
-    entityManager.persistAndFlush(dm.search());
-    Patient.Bundle patient = controller().searchByGivenAndGender("PATIENT ONE", "male", 1, 1);
-    assertThat(json(Iterables.getOnlyElement(patient.entry()).resource()))
-        .isEqualTo(json(fhir.patient()));
-  }
-
-  @Test
-  public void searchById() {
-    DatamartData dm = DatamartData.create();
-    FhirData fhir = FhirData.from(dm);
-    entityManager.persistAndFlush(dm.entity());
-    entityManager.persistAndFlush(dm.search());
-    Patient.Bundle patient = controller().searchById("false", "1011537977V693883", 1, 1);
-    assertThat(json(Iterables.getOnlyElement(patient.entry()).resource()))
-        .isEqualTo(json(fhir.patient()));
-  }
-
-  @Test
-  public void searchByIdentifier() {
-    DatamartData dm = DatamartData.create();
-    FhirData fhir = FhirData.from(dm);
-    entityManager.persistAndFlush(dm.entity());
-    entityManager.persistAndFlush(dm.search());
-    Patient.Bundle patient = controller().searchByIdentifier("false", "1011537977V693883", 1, 1);
-    assertThat(json(Iterables.getOnlyElement(patient.entry()).resource()))
-        .isEqualTo(json(fhir.patient()));
-  }
-
-  @Test
-  public void searchByNameAndBirthdate() {
-    DatamartData dm = DatamartData.create();
-    FhirData fhir = FhirData.from(dm);
-    entityManager.persistAndFlush(dm.entity());
-    entityManager.persistAndFlush(dm.search());
-    Patient.Bundle patient =
-        controller()
-            .searchByNameAndBirthdate("TEST,PATIENT ONE", new String[] {"ge1924-12-31"}, 1, 1);
-    assertThat(json(Iterables.getOnlyElement(patient.entry()).resource()))
-        .isEqualTo(json(fhir.patient()));
-  }
-
-  @Test
-  public void searchByNameAndGender() {
-    DatamartData dm = DatamartData.create();
-    FhirData fhir = FhirData.from(dm);
-    entityManager.persistAndFlush(dm.entity());
-    entityManager.persistAndFlush(dm.search());
-    Patient.Bundle patient = controller().searchByNameAndGender("TEST,PATIENT ONE", "male", 1, 1);
-    assertThat(json(Iterables.getOnlyElement(patient.entry()).resource()))
-        .isEqualTo(json(fhir.patient()));
   }
 
   @Test

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/DatamartPatientTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/DatamartPatientTest.java
@@ -67,7 +67,7 @@ public final class DatamartPatientTest {
     entityManager.persistAndFlush(dm.entity());
     entityManager.persistAndFlush(dm.search());
     Dstu2PatientController controller = controller();
-    Patient patient = controller.read(false, dm.icn());
+    Patient patient = controller.read("false", dm.icn());
     assertThat(json(patient)).isEqualTo(json(fhir.patient()));
   }
 
@@ -146,6 +146,7 @@ public final class DatamartPatientTest {
 
   public Dstu2PatientController controller() {
     return new Dstu2PatientController(
+        false,
         new Dstu2Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool", "cool")),
         repository,
         repositoryV2,
@@ -178,7 +179,7 @@ public final class DatamartPatientTest {
     PatientSearchEntity search = PatientSearchEntity.builder().icn(icn).patient(entity).build();
     entityManager.persistAndFlush(search);
     Dstu2PatientController controller = controller();
-    Patient patient = controller.read(false, icn);
+    Patient patient = controller.read("false", icn);
     assertThat(patient)
         .isEqualTo(
             Patient.builder()
@@ -476,7 +477,7 @@ public final class DatamartPatientTest {
     FhirData fhir = FhirData.from(dm);
     entityManager.persistAndFlush(dm.entity());
     entityManager.persistAndFlush(dm.search());
-    Patient.Bundle patient = controller().searchById(false, "1011537977V693883", 1, 1);
+    Patient.Bundle patient = controller().searchById("false", "1011537977V693883", 1, 1);
     assertThat(json(Iterables.getOnlyElement(patient.entry()).resource()))
         .isEqualTo(json(fhir.patient()));
   }
@@ -487,7 +488,7 @@ public final class DatamartPatientTest {
     FhirData fhir = FhirData.from(dm);
     entityManager.persistAndFlush(dm.entity());
     entityManager.persistAndFlush(dm.search());
-    Patient.Bundle patient = controller().searchByIdentifier(false, "1011537977V693883", 1, 1);
+    Patient.Bundle patient = controller().searchByIdentifier("false", "1011537977V693883", 1, 1);
     assertThat(json(Iterables.getOnlyElement(patient.entry()).resource()))
         .isEqualTo(json(fhir.patient()));
   }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/Dstu2PatientControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/Dstu2PatientControllerTest.java
@@ -79,6 +79,7 @@ public class Dstu2PatientControllerTest {
 
   Dstu2PatientController controller() {
     return new Dstu2PatientController(
+        false,
         new Dstu2Bundler(new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool", "cool")),
         repository,
         repositoryV2,
@@ -109,8 +110,8 @@ public class Dstu2PatientControllerTest {
     testEntityManager.persistAndFlush(asPatientEntity(dm));
     testEntityManager.persistAndFlush(asPatientSearchEntity(dm));
     testEntityManager.persistAndFlush(asPatientEntityV2(dm));
-    Patient actual = controller().read(false, "x");
-    Patient actualV2 = controller().read(true, "x");
+    Patient actual = controller().read("false", "x");
+    Patient actualV2 = controller().read("true", "x");
     assertThat(actual).isEqualTo(PatientSamples.Dstu2.create().patient("x"));
     assertThat(actualV2).isEqualTo(PatientSamples.Dstu2.create().patient("x"));
   }
@@ -168,8 +169,8 @@ public class Dstu2PatientControllerTest {
     testEntityManager.persistAndFlush(asPatientEntity(dm));
     testEntityManager.persistAndFlush(asPatientSearchEntity(dm));
     testEntityManager.persistAndFlush(asPatientEntityV2(dm));
-    Patient.Bundle patient = controller().searchById(false, "x", 1, 1);
-    Patient.Bundle patientV2 = controller().searchById(true, "x", 1, 1);
+    Patient.Bundle patient = controller().searchById("false", "x", 1, 1);
+    Patient.Bundle patientV2 = controller().searchById("true", "x", 1, 1);
     assertThat(json(Iterables.getOnlyElement(patient.entry()).resource()))
         .isEqualTo(json(PatientSamples.Dstu2.create().patient("x")));
     assertThat(json(Iterables.getOnlyElement(patientV2.entry()).resource()))
@@ -182,8 +183,8 @@ public class Dstu2PatientControllerTest {
     testEntityManager.persistAndFlush(asPatientEntity(dm));
     testEntityManager.persistAndFlush(asPatientSearchEntity(dm));
     testEntityManager.persistAndFlush(asPatientEntityV2(dm));
-    Patient.Bundle patient = controller().searchByIdentifier(false, "x", 1, 1);
-    Patient.Bundle patientV2 = controller().searchByIdentifier(true, "x", 1, 1);
+    Patient.Bundle patient = controller().searchByIdentifier("false", "x", 1, 1);
+    Patient.Bundle patientV2 = controller().searchByIdentifier("true", "x", 1, 1);
     assertThat(json(Iterables.getOnlyElement(patient.entry()).resource()))
         .isEqualTo(json(PatientSamples.Dstu2.create().patient("x")));
     assertThat(json(Iterables.getOnlyElement(patientV2.entry()).resource()))

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/Dstu2PatientControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/Dstu2PatientControllerTest.java
@@ -121,9 +121,12 @@ public class Dstu2PatientControllerTest {
     DatamartPatient dm = Datamart.create().patient("x");
     testEntityManager.persistAndFlush(asPatientEntity(dm));
     testEntityManager.persistAndFlush(asPatientSearchEntity(dm));
-    String json = controller().readRaw("x", response);
+    testEntityManager.persistAndFlush(asPatientEntityV2(dm));
+    String json = controller().readRaw("false", "x", response);
     assertThat(PatientEntity.builder().payload(json).build().asDatamartPatient()).isEqualTo(dm);
-    verify(response).addHeader("X-VA-INCLUDES-ICN", "x");
+    String jsonV2 = controller().readRaw("true", "x", response);
+    assertThat(PatientEntityV2.builder().payload(jsonV2).build().asDatamartPatient()).isEqualTo(dm);
+    verify(response, Mockito.times(2)).addHeader("X-VA-INCLUDES-ICN", "x");
   }
 
   @Test
@@ -131,8 +134,14 @@ public class Dstu2PatientControllerTest {
     DatamartPatient dm = Datamart.create().patient("x");
     testEntityManager.persistAndFlush(asPatientEntity(dm));
     testEntityManager.persistAndFlush(asPatientSearchEntity(dm));
-    Patient.Bundle patient = controller().searchByFamilyAndGender("Wolff180", "male", 1, 1);
+    testEntityManager.persistAndFlush(asPatientEntityV2(dm));
+    Patient.Bundle patient =
+        controller().searchByFamilyAndGender("false", "Wolff180", "male", 1, 1);
+    Patient.Bundle patientV2 =
+        controller().searchByFamilyAndGender("true", "Wolff180", "male", 1, 1);
     assertThat(json(Iterables.getOnlyElement(patient.entry()).resource()))
+        .isEqualTo(json(PatientSamples.Dstu2.create().patient("x")));
+    assertThat(json(Iterables.getOnlyElement(patientV2.entry()).resource()))
         .isEqualTo(json(PatientSamples.Dstu2.create().patient("x")));
   }
 
@@ -141,8 +150,13 @@ public class Dstu2PatientControllerTest {
     DatamartPatient dm = Datamart.create().patient("x");
     testEntityManager.persistAndFlush(asPatientEntity(dm));
     testEntityManager.persistAndFlush(asPatientSearchEntity(dm));
-    Patient.Bundle patient = controller().searchByFamilyAndGender("Wolff180", "male", 1, 0);
+    testEntityManager.persistAndFlush(asPatientEntityV2(dm));
+    Patient.Bundle patient =
+        controller().searchByFamilyAndGender("false", "Wolff180", "male", 1, 0);
+    Patient.Bundle patientV2 =
+        controller().searchByFamilyAndGender("true", "Wolff180", "male", 1, 0);
     assertThat(patient.entry()).isEqualTo(Collections.emptyList());
+    assertThat(patientV2.entry()).isEqualTo(Collections.emptyList());
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -150,7 +164,9 @@ public class Dstu2PatientControllerTest {
     DatamartPatient dm = Datamart.create().patient("x");
     testEntityManager.persistAndFlush(asPatientEntity(dm));
     testEntityManager.persistAndFlush(asPatientSearchEntity(dm));
-    controller().searchByFamilyAndGender("Wolff180", "null", 1, 0);
+    testEntityManager.persistAndFlush(asPatientEntityV2(dm));
+    controller().searchByFamilyAndGender("false", "Wolff180", "null", 1, 0);
+    controller().searchByFamilyAndGender("true", "Wolff180", "null", 1, 0);
   }
 
   @Test
@@ -158,8 +174,14 @@ public class Dstu2PatientControllerTest {
     DatamartPatient dm = Datamart.create().patient("x");
     testEntityManager.persistAndFlush(asPatientEntity(dm));
     testEntityManager.persistAndFlush(asPatientSearchEntity(dm));
-    Patient.Bundle patient = controller().searchByGivenAndGender("Tobias236", "male", 1, 1);
+    testEntityManager.persistAndFlush(asPatientEntityV2(dm));
+    Patient.Bundle patient =
+        controller().searchByGivenAndGender("false", "Tobias236", "male", 1, 1);
+    Patient.Bundle patientV2 =
+        controller().searchByGivenAndGender("false", "Tobias236", "male", 1, 1);
     assertThat(json(Iterables.getOnlyElement(patient.entry()).resource()))
+        .isEqualTo(json(PatientSamples.Dstu2.create().patient("x")));
+    assertThat(json(Iterables.getOnlyElement(patientV2.entry()).resource()))
         .isEqualTo(json(PatientSamples.Dstu2.create().patient("x")));
   }
 
@@ -196,11 +218,16 @@ public class Dstu2PatientControllerTest {
     DatamartPatient dm = Datamart.create().patient("x");
     testEntityManager.persistAndFlush(asPatientEntity(dm));
     testEntityManager.persistAndFlush(asPatientSearchEntity(dm));
+    testEntityManager.persistAndFlush(asPatientEntityV2(dm));
     Patient.Bundle patient =
         controller()
             .searchByNameAndBirthdate(
-                "Mr. Tobias236 Wolff180", new String[] {"ge1924-12-31"}, 1, 1);
-    assertThat(json(Iterables.getOnlyElement(patient.entry()).resource()))
+                "false", "Mr. Tobias236 Wolff180", new String[] {"ge1924-12-31"}, 1, 1);
+    Patient.Bundle patientV2 =
+        controller()
+            .searchByNameAndBirthdate(
+                "true", "Mr. Tobias236 Wolff180", new String[] {"ge1924-12-31"}, 1, 1);
+    assertThat(json(Iterables.getOnlyElement(patientV2.entry()).resource()))
         .isEqualTo(json(PatientSamples.Dstu2.create().patient("x")));
   }
 
@@ -209,9 +236,14 @@ public class Dstu2PatientControllerTest {
     DatamartPatient dm = Datamart.create().patient("x");
     testEntityManager.persistAndFlush(asPatientEntity(dm));
     testEntityManager.persistAndFlush(asPatientSearchEntity(dm));
+    testEntityManager.persistAndFlush(asPatientEntityV2(dm));
     Patient.Bundle patient =
-        controller().searchByNameAndGender("Mr. Tobias236 Wolff180", "male", 1, 1);
+        controller().searchByNameAndGender("false", "Mr. Tobias236 Wolff180", "male", 1, 1);
+    Patient.Bundle patientV2 =
+        controller().searchByNameAndGender("true", "Mr. Tobias236 Wolff180", "male", 1, 1);
     assertThat(json(Iterables.getOnlyElement(patient.entry()).resource()))
+        .isEqualTo(json(PatientSamples.Dstu2.create().patient("x")));
+    assertThat(json(Iterables.getOnlyElement(patientV2.entry()).resource()))
         .isEqualTo(json(PatientSamples.Dstu2.create().patient("x")));
   }
 }


### PR DESCRIPTION
*****DO NOT MERGE: DU CHANGES REQUIRED FIRST*****

Change to support PatientEntityV2 and PatientEntity + PatientSearchEntity simultaneously via a feature toggle. 

Feature toggle header is in place, defaults to false `-HpatientV2: true`

To test this, you will need the new local DQDB seen here:
https://github.com/department-of-veterans-affairs/health-apis-datamart-synthetic-records/pull/25

