### PR TITLE
DQ can return 405 not allowed

### DIFF
--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/WebExceptionHandler.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/WebExceptionHandler.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.UnsatisfiedServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -192,6 +193,12 @@ public class WebExceptionHandler {
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public OperationOutcome handleBadRequest(Exception e, HttpServletRequest request) {
     return responseFor("structure", e, request, emptyList(), true);
+  }
+
+  @ExceptionHandler({HttpRequestMethodNotSupportedException.class})
+  @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+  public OperationOutcome handleNotAllowed(Exception e, HttpServletRequest request) {
+    return responseFor("not-allowed", e, request, emptyList(), true);
   }
 
   @ExceptionHandler({

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/WebExceptionHandlerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/WebExceptionHandlerTest.java
@@ -3,8 +3,10 @@ package gov.va.api.health.dataquery.service.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -33,6 +35,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.method.annotation.ExceptionHandlerMethodResolver;
 import org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver;
@@ -140,5 +143,21 @@ public class WebExceptionHandlerTest {
         .andExpect(jsonPath("extension[1].url", equalTo("type")))
         .andExpect(
             jsonPath("extension[1].valueString", equalTo(exception.getClass().getSimpleName())));
+  }
+
+  @Test
+  @SneakyThrows
+  public void unsupportedMethodThrowsNotAllowed() {
+    MockMvc mvc =
+        MockMvcBuilders.standaloneSetup(controller)
+            .setHandlerExceptionResolvers(createExceptionResolver())
+            .setMessageConverters()
+            .build();
+    mvc.perform(post(basePath + "/Patient/123"))
+        .andExpect(
+            result ->
+                assertTrue(
+                    result.getResolvedException()
+                        instanceof HttpRequestMethodNotSupportedException));
   }
 }


### PR DESCRIPTION
`$  curl -v -X PUT "http://localhost:8090/r4/AllergyIntolerance?patient=1011537977V69388"`
```
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8090 (#0)
> PUT /r4/AllergyIntolerance?patient=1011537977V69388 HTTP/1.1
> Host: localhost:8090
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 405 
< Content-Type: application/json
< Transfer-Encoding: chunked
< Date: Fri, 19 Jun 2020 14:29:04 GMT
< 
* Connection #0 to host localhost left intact
```
`{"id":"125fab34-cb00-4af0-864a-f06ac4fa126d","resourceType":"OperationOutcome","text":{"status":"additional","div":"<div>Failure: /r4/AllergyIntolerance</div>"},"extension":[{"url":"timestamp","valueInstant":"2020-06-19T14:29:04.663765Z"},{"url":"type","valueString":"HttpRequestMethodNotSupportedException"},{"url":"message","valueString":"TCekfQVQRWq+yRceAQsUf/8dzo8CIF2RdGKf9R5FgCDbDHlHvpnzsXGfisetwYY7pX7LIhhSIFsRrCPRna5riyNo"},{"url":"request","valueString":"/r4/AllergyIntolerance?patient=1011537977V69388"}],"issue":[{"severity":"fatal","code":"not-allowed"}]}`