### PR TITLE
API-1271-fix-regex

### DIFF
--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/ResourceVerifier.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/ResourceVerifier.java
@@ -205,7 +205,7 @@ public final class ResourceVerifier {
     String body;
 
     String body() {
-      return String.format(body.replaceAll("[{][a-z]+[}]", "%s"), parameters);
+      return String.format(body.replaceAll("[{][a-z0-9]+[}]", "%s"), parameters);
     }
 
     Boolean isPost() {


### PR DESCRIPTION
The loinc codes use numbers for their values (i.e. `{loinc1}`) this fixes the substitution for those codes.