### PR TITLE
Update health-apis-ids version for data-query to latest

### DIFF
--- a/data-query-ids-mapping/pom.xml
+++ b/data-query-ids-mapping/pom.xml
@@ -11,7 +11,7 @@
   <version>3.0.7-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
-    <health-apis-ids.version>3.0.1</health-apis-ids.version>
+    <health-apis-ids.version>3.0.2</health-apis-ids.version>
     <jacoco.coverage>0.94</jacoco.coverage>
   </properties>
   <dependencies>

--- a/data-query-tests/pom.xml
+++ b/data-query-tests/pom.xml
@@ -12,7 +12,7 @@
   <packaging>jar</packaging>
   <properties>
     <fhir-resources.version>4.0.2</fhir-resources.version>
-    <health-apis-ids.version>3.0.1</health-apis-ids.version>
+    <health-apis-ids.version>3.0.2</health-apis-ids.version>
     <selenium.version>3.141.59</selenium.version>
     <sentinel.skipLaunch>false</sentinel.skipLaunch>
   </properties>

--- a/data-query/pom.xml
+++ b/data-query/pom.xml
@@ -14,7 +14,7 @@
     <fall-risk.version>1.0.29</fall-risk.version>
     <fhir-resources.version>4.0.2</fhir-resources.version>
     <guava.version>29.0-jre</guava.version>
-    <health-apis-ids.version>3.0.1</health-apis-ids.version>
+    <health-apis-ids.version>3.0.2</health-apis-ids.version>
     <mssql-jdbc.version>7.4.1.jre8</mssql-jdbc.version>
     <swagger-maven-plugin.version>2.1.1</swagger-maven-plugin.version>
   </properties>


### PR DESCRIPTION
https://vajira.max.gov/browse/API-1616
Update to 3.0.2 for health apis ids version.