### PR TITLE
API 2164 oauth v1 support

### DIFF
--- a/data-query-tests/.gitignore
+++ b/data-query-tests/.gitignore
@@ -1,4 +1,4 @@
 src/test/resources/mitre.trace.db
 lab-users.txt
 .lab-users
-
+lab-user.conf

--- a/data-query-tests/lab-login
+++ b/data-query-tests/lab-login
@@ -4,9 +4,10 @@ cd $(dirname $(readlink -f $0))
 
 usage() {
 cat <<EOF
-$0 [options] [email]
+$0 [options] [email|user-id]
 
 Performs OAuth login for lab users and prints their login ID and an access token.
+See all-lab-users.txt for valid email addresses or user ids.
 
 Options
 -h, --help   Print this help and exit
@@ -27,8 +28,21 @@ trap onExit EXIT
 
 LAB_USER="$1"
 FILTER=" "
-[ -n "$LAB_USER" ] && LOGIN_ARGS="-Dlab.user=$LAB_USER" && FILTER="$LAB_USER"
 
+
+if [ -n "$LAB_USER" ]
+then
+  if [[ "$LAB_USER" != *@* ]]
+  then
+    LAB_USER=$(grep -E "gmail.com $LAB_USER\$" all-lab-users.txt | cut -d ' ' -f 1)
+    if [ -z "$LAB_USER" ]
+    then
+      usage "Did not find email address for user $1"
+    fi
+  fi
+  LOGIN_ARGS="-Dlab.user=$LAB_USER"
+  FILTER="$LAB_USER"
+fi
 
 mvn -P'!standard' test \
   -Dgroups= \

--- a/data-query-tests/lab-login
+++ b/data-query-tests/lab-login
@@ -59,3 +59,4 @@ USERS_FILE=lab-users.txt
 
 
 cat $USERS_FILE | cut -d ' ' -f 1,6 | grep -F "$FILTER"
+cat $USERS_FILE | awk '{print "LAB_EMAIL=\"" $1 "\""; print "LAB_USER=\"" $4 "\""; print "LAB_TOKEN=\"" $6 "\""}' > lab-user.conf


### PR DESCRIPTION
- lab-login now supports user IDs in addition to emails.
- lab-login now generates a lab-user.conf file that can be sourced for easier scripting. It contains LAB_EMAIL, LAB_USER, and LAB_TOKEN variables

Usage
```
$ lab-login 17 && . lab-user.conf
curl -sH"Authorization: Bearer $LAB_TOKEN" https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/$LAB_USER
```
