### PR TITLE
add MedicationRequest scope

### DIFF
--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/DataQueryScopes.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/DataQueryScopes.java
@@ -15,6 +15,7 @@ public class DataQueryScopes {
         "patient/Immunization.read",
         "patient/Medication.read",
         "patient/MedicationOrder.read",
+        "patient/MedicationRequest.read",
         "patient/MedicationStatement.read",
         "patient/Observation.read",
         "patient/Patient.read",


### PR DESCRIPTION
https://vajira.max.gov/browse/API-3242 

All scopes listed couldnt be added at this time, but MedicationRequest could.

Talks are ongoing about adding the others to the authentication server.