### PR TITLE
remove workaround for duplicate observation records

### DIFF
--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/Dstu2ObservationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/Dstu2ObservationController.java
@@ -20,9 +20,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
@@ -101,13 +98,7 @@ public class Dstu2ObservationController {
 
   ObservationEntity findById(@PathVariable("publicId") String publicId) {
     String cdwId = witnessProtection.toCdwId(publicId);
-    // DUPLICATES IN CDW ARE CAUSING THIS TO FAIL: repository.findById(cdwId);
-    Optional<ObservationEntity> maybeEntity =
-        repository.findOne(
-            (Root<ObservationEntity> root,
-                CriteriaQuery<?> criteriaQuery,
-                CriteriaBuilder criteriaBuilder) ->
-                criteriaBuilder.equal(root.get("cdwId"), cdwId));
+    Optional<ObservationEntity> maybeEntity = repository.findById(cdwId);
     if (!maybeEntity.isPresent()) {
       throw new ResourceExceptions.NotFound(publicId);
     }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/R4ObservationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/R4ObservationController.java
@@ -21,9 +21,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
@@ -221,13 +218,7 @@ public class R4ObservationController {
 
   ObservationEntity findById(String publicId) {
     String cdwId = witnessProtection.toCdwId(publicId);
-    // DUPLICATES IN CDW ARE CAUSING THIS TO FAIL: repository.findById(cdwId);
-    Optional<ObservationEntity> maybeEntity =
-        repository.findOne(
-            (Root<ObservationEntity> root,
-                CriteriaQuery<?> criteriaQuery,
-                CriteriaBuilder criteriaBuilder) ->
-                criteriaBuilder.equal(root.get("cdwId"), cdwId));
+    Optional<ObservationEntity> maybeEntity = repository.findById(cdwId);
     return maybeEntity.orElseThrow(() -> new ResourceExceptions.NotFound(publicId));
   }
 


### PR DESCRIPTION
"The Observation_LabChem PostProcessing has completed. You should be good to remove the work around code".