### PR TITLE
API-6195-search-by-id-404

### DIFF
--- a/data-query-ids-mapping/pom.xml
+++ b/data-query-ids-mapping/pom.xml
@@ -8,7 +8,7 @@
     <relativePath/>
   </parent>
   <artifactId>data-query-ids-mapping</artifactId>
-  <version>3.0.139</version>
+  <version>3.0.140-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
     <health-apis-ids.version>3.0.11</health-apis-ids.version>

--- a/data-query-ids-mapping/pom.xml
+++ b/data-query-ids-mapping/pom.xml
@@ -8,7 +8,7 @@
     <relativePath/>
   </parent>
   <artifactId>data-query-ids-mapping</artifactId>
-  <version>3.0.139-SNAPSHOT</version>
+  <version>3.0.139</version>
   <packaging>jar</packaging>
   <properties>
     <health-apis-ids.version>3.0.11</health-apis-ids.version>

--- a/data-query-patient-registration/pom.xml
+++ b/data-query-patient-registration/pom.xml
@@ -8,7 +8,7 @@
     <relativePath/>
   </parent>
   <artifactId>data-query-patient-registration</artifactId>
-  <version>3.0.139</version>
+  <version>3.0.140-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
     <!-- DYNAMO DB AND AWS SDK VERSION NUMBERS ARE MATCHED -->

--- a/data-query-patient-registration/pom.xml
+++ b/data-query-patient-registration/pom.xml
@@ -8,7 +8,7 @@
     <relativePath/>
   </parent>
   <artifactId>data-query-patient-registration</artifactId>
-  <version>3.0.139-SNAPSHOT</version>
+  <version>3.0.139</version>
   <packaging>jar</packaging>
   <properties>
     <!-- DYNAMO DB AND AWS SDK VERSION NUMBERS ARE MATCHED -->

--- a/data-query-tests/pom.xml
+++ b/data-query-tests/pom.xml
@@ -8,7 +8,7 @@
     <relativePath/>
   </parent>
   <artifactId>data-query-tests</artifactId>
-  <version>3.0.139</version>
+  <version>3.0.140-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
     <fhir-resources.version>6.0.9</fhir-resources.version>

--- a/data-query-tests/pom.xml
+++ b/data-query-tests/pom.xml
@@ -8,7 +8,7 @@
     <relativePath/>
   </parent>
   <artifactId>data-query-tests</artifactId>
-  <version>3.0.139-SNAPSHOT</version>
+  <version>3.0.139</version>
   <packaging>jar</packaging>
   <properties>
     <fhir-resources.version>6.0.9</fhir-resources.version>

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/AllergyIntoleranceIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/AllergyIntoleranceIT.java
@@ -1,6 +1,5 @@
 package gov.va.api.health.dataquery.tests.r4;
 
-import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentIn;
 import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentNotIn;
 
 import gov.va.api.health.dataquery.tests.DataQueryResourceVerifier;
@@ -18,29 +17,32 @@ public class AllergyIntoleranceIT {
   TestIds testIds = DataQueryResourceVerifier.ids();
 
   @Test
-  public void advanced() {
-    assumeEnvironmentIn(Environment.LOCAL);
-    verifier.verifyAll(
+  public void read() {
+    verifyAll(
+        test(
+            200, AllergyIntolerance.class, "AllergyIntolerance/{id}", testIds.allergyIntolerance()),
+        test(404, OperationOutcome.class, "AllergyIntolerance/{id}", testIds.unknown()));
+  }
+
+  @Test
+  public void search() {
+    verifyAll(
         test(
             200,
             AllergyIntolerance.Bundle.class,
             "AllergyIntolerance?_id={id}",
             testIds.allergyIntolerance()),
-        test(404, OperationOutcome.class, "AllergyIntolerance?_id={id}", testIds.unknown()),
+        test(
+            200,
+            AllergyIntolerance.Bundle.class,
+            b -> b.entry().isEmpty(),
+            "AllergyIntolerance?_id={id}",
+            testIds.unknown()),
         test(
             200,
             AllergyIntolerance.Bundle.class,
             "AllergyIntolerance?identifier={id}",
-            testIds.allergyIntolerance()));
-  }
-
-  @Test
-  public void basic() {
-
-    verifier.verifyAll(
-        test(
-            200, AllergyIntolerance.class, "AllergyIntolerance/{id}", testIds.allergyIntolerance()),
-        test(404, OperationOutcome.class, "AllergyIntolerance/{id}", testIds.unknown()),
+            testIds.allergyIntolerance()),
         test(
             200,
             AllergyIntolerance.Bundle.class,
@@ -50,9 +52,7 @@ public class AllergyIntoleranceIT {
 
   @Test
   public void searchNotMe() {
-
     assumeEnvironmentNotIn(Environment.LOCAL);
-
     verifier.verifyAll(
         test(
             403,

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/ConditionIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/ConditionIT.java
@@ -1,6 +1,5 @@
 package gov.va.api.health.dataquery.tests.r4;
 
-import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentIn;
 import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentNotIn;
 
 import gov.va.api.health.dataquery.tests.DataQueryResourceVerifier;
@@ -18,9 +17,15 @@ public class ConditionIT {
   TestIds testIds = DataQueryResourceVerifier.ids();
 
   @Test
-  public void advanced() {
-    assumeEnvironmentIn(Environment.LOCAL);
-    verifier.verifyAll(
+  void read() {
+    verifyAll(
+        test(200, Condition.class, "Condition/{id}", testIds.condition()),
+        test(404, OperationOutcome.class, "Condition/{id}", testIds.unknown()));
+  }
+
+  @Test
+  public void search() {
+    verifyAll(
         test(200, Condition.Bundle.class, "Condition?_id={id}", testIds.condition()),
         test(
             200,
@@ -28,12 +33,7 @@ public class ConditionIT {
             r -> r.entry().isEmpty(),
             "Condition?_id={id}",
             testIds.unknown()),
-        test(200, Condition.Bundle.class, "Condition?identifier={id}", testIds.condition()));
-  }
-
-  @Test
-  public void basic() {
-    verifier.verifyAll(
+        test(200, Condition.Bundle.class, "Condition?identifier={id}", testIds.condition()),
         test(
             200,
             Condition.Bundle.class,
@@ -54,8 +54,6 @@ public class ConditionIT {
             Condition.Bundle.class,
             "Condition?patient={patient}&clinical-status=http://terminology.hl7.org/CodeSystem/condition-clinical|active,resolved",
             testIds.patient()),
-        test(200, Condition.class, "Condition/{id}", testIds.condition()),
-        test(404, OperationOutcome.class, "Condition/{id}", testIds.unknown()),
         test(200, Condition.Bundle.class, "Condition?patient={patient}", testIds.patient()));
   }
 

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/DeviceIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/DeviceIT.java
@@ -1,6 +1,5 @@
 package gov.va.api.health.dataquery.tests.r4;
 
-import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentIn;
 import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentNotIn;
 
 import gov.va.api.health.dataquery.tests.DataQueryResourceVerifier;
@@ -18,22 +17,15 @@ public class DeviceIT {
   TestIds testIds = DataQueryResourceVerifier.ids();
 
   @Test
-  public void basic() {
-    verifier.verifyAll(
+  public void read() {
+    verifyAll(
         test(200, Device.class, "Device/{id}", testIds.device()),
-        test(404, OperationOutcome.class, "Device/{id}", testIds.unknown()),
-        test(200, Device.Bundle.class, "Device?patient={patientIcn}", testIds.patient()),
-        test(
-            200,
-            Device.Bundle.class,
-            "Device?patient={patientIcn}&type=http://snomed.info/sct|53350007",
-            testIds.patient()));
+        test(404, OperationOutcome.class, "Device/{id}", testIds.unknown()));
   }
 
   @Test
-  void searchByIdentifier() {
-    assumeEnvironmentIn(Environment.LOCAL);
-    verifier.verifyAll(
+  void search() {
+    verifyAll(
         test(200, Device.Bundle.class, "Device?_id={id}", testIds.device()),
         test(
             200,
@@ -47,13 +39,18 @@ public class DeviceIT {
             Device.Bundle.class,
             d -> d.entry().isEmpty(),
             "Device?identifier={id}",
-            testIds.unknown()));
+            testIds.unknown()),
+        test(200, Device.Bundle.class, "Device?patient={patientIcn}", testIds.patient()),
+        test(
+            200,
+            Device.Bundle.class,
+            "Device?patient={patientIcn}&type=http://snomed.info/sct|53350007",
+            testIds.patient()));
   }
 
   @Test
   void searchNotMe() {
     assumeEnvironmentNotIn(Environment.LOCAL);
-    verifier.verifyAll(
-        test(403, OperationOutcome.class, "Device?patient={patient}", testIds.unknown()));
+    verifyAll(test(403, OperationOutcome.class, "Device?patient={patient}", testIds.unknown()));
   }
 }

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/DiagnosticReportIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/DiagnosticReportIT.java
@@ -1,6 +1,5 @@
 package gov.va.api.health.dataquery.tests.r4;
 
-import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentIn;
 import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentNotIn;
 
 import gov.va.api.health.dataquery.tests.DataQueryResourceVerifier;
@@ -18,18 +17,42 @@ public class DiagnosticReportIT {
   TestIds testIds = DataQueryResourceVerifier.ids();
 
   @Test
-  public void basic() {
+  public void read() {
     verifier.verifyAll(
-        // Reads
         test(200, DiagnosticReport.class, "DiagnosticReport/{id}", testIds.diagnosticReport()),
-        test(404, OperationOutcome.class, "DiagnosticReport/{id}", testIds.unknown()),
-        // Search By Patient
+        test(404, OperationOutcome.class, "DiagnosticReport/{id}", testIds.unknown()));
+  }
+
+  @Test
+  public void search() {
+    verifyAll( // Search By Id
+        test(
+            200,
+            DiagnosticReport.Bundle.class,
+            "DiagnosticReport?_id={id}",
+            testIds.diagnosticReport()),
+        test(
+            200,
+            DiagnosticReport.Bundle.class,
+            b -> b.entry().isEmpty(),
+            "DiagnosticReport?_id={id}",
+            testIds.unknown()),
+        test(
+            200,
+            DiagnosticReport.Bundle.class,
+            "DiagnosticReport?identifier={id}",
+            testIds.diagnosticReport()),
+        test(
+            200,
+            DiagnosticReport.Bundle.class,
+            b -> b.entry().isEmpty(),
+            "DiagnosticReport?identifier={id}",
+            testIds.unknown()), // Search By Patient
         test(
             200,
             DiagnosticReport.Bundle.class,
             "DiagnosticReport?patient={patient}",
-            testIds.patient()),
-        // Search By Patient and Category (and Date)
+            testIds.patient()), // Search By Patient and Category (and Date)
         test(
             200,
             DiagnosticReport.Bundle.class,
@@ -137,8 +160,7 @@ public class DiagnosticReportIT {
             DiagnosticReport.Bundle.class,
             "DiagnosticReport?patient={patient}&category=LAB&date={dateLessThan}",
             testIds.patient(),
-            testIds.diagnosticReports().dateLessThan()),
-        // Search By Patient and Code (and Date)
+            testIds.diagnosticReports().dateLessThan()), // Search By Patient and Code (and Date)
         test(
             200,
             DiagnosticReport.Bundle.class,
@@ -162,31 +184,12 @@ public class DiagnosticReportIT {
             "DiagnosticReport?patient={patient}&code=&date={fromDate}&date={toDate}",
             testIds.patient(),
             testIds.diagnosticReports().fromDate(),
-            testIds.diagnosticReports().toDate()),
-        // Search By Patient and Status
+            testIds.diagnosticReports().toDate()), // Search By Patient and Status
         test(
             200,
             DiagnosticReport.Bundle.class,
             "DiagnosticReport?patient={patient}&status=final",
             testIds.patient()));
-  }
-
-  @Test
-  public void searchByIdentifier() {
-    assumeEnvironmentIn(Environment.LOCAL);
-    verifier.verifyAll(
-        test(
-            200,
-            DiagnosticReport.Bundle.class,
-            "DiagnosticReport?_id={id}",
-            testIds.diagnosticReport()),
-        test(404, OperationOutcome.class, "DiagnosticReport?_id={id}", testIds.unknown()),
-        test(
-            200,
-            DiagnosticReport.Bundle.class,
-            "DiagnosticReport?identifier={id}",
-            testIds.diagnosticReport()),
-        test(404, OperationOutcome.class, "DiagnosticReport?identifier={id}", testIds.unknown()));
   }
 
   @Test

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/ImmunizationIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/ImmunizationIT.java
@@ -1,6 +1,5 @@
 package gov.va.api.health.dataquery.tests.r4;
 
-import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentIn;
 import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentNotIn;
 
 import gov.va.api.health.dataquery.tests.DataQueryResourceVerifier;
@@ -18,24 +17,28 @@ public class ImmunizationIT {
   TestIds testIds = DataQueryResourceVerifier.ids();
 
   @Test
-  public void advanced() {
-    assumeEnvironmentIn(Environment.LOCAL);
-    verifier.verifyAll(
+  public void basic() {
+    verifyAll(
+        test(200, Immunization.class, "Immunization/{id}", testIds.immunization()),
+        test(404, OperationOutcome.class, "Immunization/{id}", testIds.unknown()));
+  }
+
+  @Test
+  public void search() {
+    verifyAll(
         test(200, Immunization.Bundle.class, "Immunization?_id={id}", testIds.immunization()),
-        test(404, OperationOutcome.class, "Immunization?_id={id}", testIds.unknown()),
+        test(
+            200,
+            Immunization.Bundle.class,
+            b -> b.entry().isEmpty(),
+            "Immunization?_id={id}",
+            testIds.unknown()),
+        test(200, Immunization.Bundle.class, "Immunization?patient={patient}", testIds.patient()),
         test(
             200,
             Immunization.Bundle.class,
             "Immunization?identifier={id}",
             testIds.immunization()));
-  }
-
-  @Test
-  public void basic() {
-    verifier.verifyAll(
-        test(200, Immunization.class, "Immunization/{id}", testIds.immunization()),
-        test(404, OperationOutcome.class, "Immunization/{id}", testIds.unknown()),
-        test(200, Immunization.Bundle.class, "Immunization?patient={patient}", testIds.patient()));
   }
 
   @Test

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/LocationIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/LocationIT.java
@@ -18,10 +18,20 @@ public class LocationIT {
     verifyAll(
         // Search by _id
         test(200, Location.Bundle.class, "Location?_id={id}", testIds.location()),
-        test(404, OperationOutcome.class, "Location?_id={id}", testIds.unknown()),
+        test(
+            200,
+            Location.Bundle.class,
+            b -> b.entry().isEmpty(),
+            "Location?_id={id}",
+            testIds.unknown()),
         // Search by identifier
         test(200, Location.Bundle.class, "Location?identifier={id}", testIds.location()),
-        test(404, OperationOutcome.class, "Location?identifier={id}", testIds.unknown()),
+        test(
+            200,
+            Location.Bundle.class,
+            b -> b.entry().isEmpty(),
+            "Location?identifier={id}",
+            testIds.unknown()),
         // Search by name
         test(200, Location.Bundle.class, "Location?name={name}", testIds.locations().name()),
         // Search by address

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/MedicationIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/MedicationIT.java
@@ -1,13 +1,10 @@
 package gov.va.api.health.dataquery.tests.r4;
 
-import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentIn;
-
 import gov.va.api.health.dataquery.tests.DataQueryResourceVerifier;
 import gov.va.api.health.dataquery.tests.TestIds;
 import gov.va.api.health.fhir.testsupport.ResourceVerifier;
 import gov.va.api.health.r4.api.resources.Medication;
 import gov.va.api.health.r4.api.resources.OperationOutcome;
-import gov.va.api.health.sentinel.Environment;
 import lombok.experimental.Delegate;
 import org.junit.jupiter.api.Test;
 
@@ -17,18 +14,22 @@ public class MedicationIT {
   TestIds testIds = DataQueryResourceVerifier.ids();
 
   @Test
-  public void advanced() {
-    assumeEnvironmentIn(Environment.LOCAL);
-    verifier.verifyAll(
-        test(200, Medication.Bundle.class, "Medication?_id={id}", testIds.medication()),
-        test(404, OperationOutcome.class, "Medication?_id={id}", testIds.unknown()),
-        test(200, Medication.Bundle.class, "Medication?identifier={id}", testIds.medication()));
+  public void read() {
+    verifyAll(
+        test(200, Medication.class, "Medication/{id}", testIds.medication()),
+        test(404, OperationOutcome.class, "Medication/{id}", testIds.unknown()));
   }
 
   @Test
-  public void basic() {
-    verifier.verifyAll(
-        test(200, Medication.class, "Medication/{id}", testIds.medication()),
-        test(404, OperationOutcome.class, "Medication/{id}", testIds.unknown()));
+  public void search() {
+    verifyAll(
+        test(200, Medication.Bundle.class, "Medication?_id={id}", testIds.medication()),
+        test(
+            200,
+            Medication.Bundle.class,
+            b -> b.entry().isEmpty(),
+            "Medication?_id={id}",
+            testIds.unknown()),
+        test(200, Medication.Bundle.class, "Medication?identifier={id}", testIds.medication()));
   }
 }

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/MedicationRequestIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/MedicationRequestIT.java
@@ -1,6 +1,5 @@
 package gov.va.api.health.dataquery.tests.r4;
 
-import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentIn;
 import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentNotIn;
 
 import gov.va.api.health.dataquery.tests.DataQueryResourceVerifier;
@@ -18,9 +17,17 @@ public class MedicationRequestIT {
   TestIds testIds = DataQueryResourceVerifier.ids();
 
   @Test
-  public void advanced() {
-    assumeEnvironmentIn(Environment.LOCAL);
-    verifier.verifyAll(
+  public void read() {
+    verifyAll(
+        // MedicationRequest Public Id
+        test(200, MedicationRequest.class, "MedicationRequest/{id}", testIds.medicationOrder()),
+        test(200, MedicationRequest.class, "MedicationRequest/{id}", testIds.medicationStatement()),
+        test(404, OperationOutcome.class, "MedicationRequest/{id}", testIds.unknown()));
+  }
+
+  @Test
+  public void search() {
+    verifyAll(
         test(
             200,
             MedicationRequest.Bundle.class,
@@ -31,7 +38,12 @@ public class MedicationRequestIT {
             MedicationRequest.Bundle.class,
             "MedicationRequest?_id={id}",
             testIds.medicationStatement()),
-        test(404, OperationOutcome.class, "MedicationRequest?_id={id}", testIds.unknown()),
+        test(
+            200,
+            MedicationRequest.Bundle.class,
+            b -> b.entry().isEmpty(),
+            "MedicationRequest?_id={id}",
+            testIds.unknown()),
         test(
             200,
             MedicationRequest.Bundle.class,
@@ -41,12 +53,7 @@ public class MedicationRequestIT {
             200,
             MedicationRequest.Bundle.class,
             "MedicationRequest?identifier={id}",
-            testIds.medicationStatement()));
-  }
-
-  @Test
-  public void basic() {
-    verifier.verifyAll(
+            testIds.medicationStatement()),
         // Patient And Intent
         test(
             200,
@@ -58,10 +65,6 @@ public class MedicationRequestIT {
             MedicationRequest.Bundle.class,
             "MedicationRequest?patient={patient}&intent=plan",
             testIds.patient()),
-        // MedicationRequest Public Id
-        test(200, MedicationRequest.class, "MedicationRequest/{id}", testIds.medicationOrder()),
-        test(200, MedicationRequest.class, "MedicationRequest/{id}", testIds.medicationStatement()),
-        test(404, OperationOutcome.class, "MedicationRequest/{id}", testIds.unknown()),
         // Patient Icn
         test(
             200,

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/ObservationIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/ObservationIT.java
@@ -1,6 +1,5 @@
 package gov.va.api.health.dataquery.tests.r4;
 
-import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentIn;
 import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentNotIn;
 
 import gov.va.api.health.dataquery.tests.DataQueryResourceVerifier;
@@ -18,9 +17,16 @@ public class ObservationIT {
   TestIds testIds = DataQueryResourceVerifier.ids();
 
   @Test
-  public void advanced() {
-    assumeEnvironmentIn(Environment.LOCAL);
-    verifier.verifyAll(
+  void read() {
+    verifyAll(
+        test(200, Observation.class, "Observation/{id}", testIds.observation()),
+        test(404, OperationOutcome.class, "Observation/{id}", testIds.unknown()));
+  }
+
+  @Test
+  void search() {
+    verifyAll(
+        // ID and Identifier
         test(200, Observation.Bundle.class, "Observation?_id={id}", testIds.observation()),
         test(
             200,
@@ -28,12 +34,7 @@ public class ObservationIT {
             r -> r.entry().isEmpty(),
             "Observation?_id={id}",
             testIds.unknown()),
-        test(200, Observation.Bundle.class, "Observation?identifier={id}", testIds.observation()));
-  }
-
-  @Test
-  public void basic() {
-    verifier.verifyAll(
+        test(200, Observation.Bundle.class, "Observation?identifier={id}", testIds.observation()),
         // Patient And Category
         test(
             200,
@@ -104,9 +105,6 @@ public class ObservationIT {
             testIds.patient(),
             testIds.observations().loinc1(),
             testIds.observations().badLoinc()),
-        // Observation Public Id
-        test(200, Observation.class, "Observation/{id}", testIds.observation()),
-        test(404, OperationOutcome.class, "Observation/{id}", testIds.unknown()),
         // Patient Icn
         test(200, Observation.Bundle.class, "Observation?patient={patient}", testIds.patient()));
   }
@@ -114,7 +112,7 @@ public class ObservationIT {
   @Test
   public void searchNotMe() {
     assumeEnvironmentNotIn(Environment.LOCAL);
-    verifier.verifyAll(
+    verifyAll(
         test(403, OperationOutcome.class, "Observation?patient={patient}", testIds.unknown()));
   }
 }

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/OrganizationIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/OrganizationIT.java
@@ -1,13 +1,10 @@
 package gov.va.api.health.dataquery.tests.r4;
 
-import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentIn;
-
 import gov.va.api.health.dataquery.tests.DataQueryResourceVerifier;
 import gov.va.api.health.dataquery.tests.TestIds;
 import gov.va.api.health.fhir.testsupport.ResourceVerifier;
 import gov.va.api.health.r4.api.resources.OperationOutcome;
 import gov.va.api.health.r4.api.resources.Organization;
-import gov.va.api.health.sentinel.Environment;
 import java.util.function.Predicate;
 import lombok.experimental.Delegate;
 import org.junit.jupiter.api.Test;
@@ -17,8 +14,19 @@ public class OrganizationIT {
 
   TestIds testIds = DataQueryResourceVerifier.ids();
 
+  private Predicate<Organization.Bundle> bundleIsNotEmpty() {
+    return bundle -> !bundle.entry().isEmpty();
+  }
+
   @Test
-  void advanced() {
+  void read() {
+    verifyAll(
+        test(200, Organization.class, "Organization/{id}", testIds.organization()),
+        test(404, OperationOutcome.class, "Organization/{id}", testIds.unknown()));
+  }
+
+  @Test
+  void search() {
     verifyAll(
         test(
             200,
@@ -29,9 +37,21 @@ public class OrganizationIT {
         test(
             200,
             Organization.Bundle.class,
+            bundleIsNotEmpty().negate(),
+            "Organization?_id={id}",
+            testIds.unknown()),
+        test(
+            200,
+            Organization.Bundle.class,
             bundleIsNotEmpty(),
             "Organization?identifier={id}",
             testIds.organization()),
+        test(
+            200,
+            Organization.Bundle.class,
+            bundleIsNotEmpty(),
+            "Organization?identifier={facilityId}",
+            testIds.organizations().facilityId()),
         test(
             200,
             Organization.Bundle.class,
@@ -68,28 +88,5 @@ public class OrganizationIT {
             bundleIsNotEmpty(),
             "Organization?address-postalcode={zip}",
             testIds.organizations().addressPostalCode()));
-  }
-
-  @Test
-  void basic() {
-    verifyAll(
-        test(200, Organization.class, "Organization/{id}", testIds.organization()),
-        test(404, OperationOutcome.class, "Organization/{id}", testIds.unknown()));
-  }
-
-  private Predicate<Organization.Bundle> bundleIsNotEmpty() {
-    return bundle -> !bundle.entry().isEmpty();
-  }
-
-  @Test
-  void local() {
-    assumeEnvironmentIn(Environment.LOCAL);
-    verify(
-        test(
-            200,
-            Organization.Bundle.class,
-            bundleIsNotEmpty().negate(),
-            "Organization?_id={id}",
-            testIds.unknown()));
   }
 }

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerIT.java
@@ -1,13 +1,11 @@
 package gov.va.api.health.dataquery.tests.r4;
 
-import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentIn;
 
 import gov.va.api.health.dataquery.tests.DataQueryResourceVerifier;
 import gov.va.api.health.dataquery.tests.TestIds;
 import gov.va.api.health.fhir.testsupport.ResourceVerifier;
 import gov.va.api.health.r4.api.resources.OperationOutcome;
 import gov.va.api.health.r4.api.resources.Practitioner;
-import gov.va.api.health.sentinel.Environment;
 import lombok.experimental.Delegate;
 import org.junit.jupiter.api.Test;
 
@@ -15,14 +13,6 @@ public class PractitionerIT {
   @Delegate ResourceVerifier verifier = DataQueryResourceVerifier.r4();
 
   TestIds testIds = DataQueryResourceVerifier.ids();
-
-  @Test
-  public void malformed() {
-    assumeEnvironmentIn(Environment.LOCAL);
-    verifier.verifyAll(
-        test(400, OperationOutcome.class, "Practitioner/"),
-        test(400, OperationOutcome.class, "Practitioner?nonsense=abc"));
-  }
 
   @Test
   public void read() {

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerIT.java
@@ -1,6 +1,5 @@
 package gov.va.api.health.dataquery.tests.r4;
 
-
 import gov.va.api.health.dataquery.tests.DataQueryResourceVerifier;
 import gov.va.api.health.dataquery.tests.TestIds;
 import gov.va.api.health.fhir.testsupport.ResourceVerifier;

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerIT.java
@@ -17,17 +17,24 @@ public class PractitionerIT {
   TestIds testIds = DataQueryResourceVerifier.ids();
 
   @Test
-  public void basic() {
+  public void malformed() {
+    assumeEnvironmentIn(Environment.LOCAL);
     verifier.verifyAll(
+        test(400, OperationOutcome.class, "Practitioner/"),
+        test(400, OperationOutcome.class, "Practitioner?nonsense=abc"));
+  }
+
+  @Test
+  public void read() {
+    verifyAll(
         test(200, Practitioner.class, "Practitioner/{id}", testIds.practitioner()),
         test(200, Practitioner.class, "Practitioner/npi-{npi}", testIds.practitioners().npi()),
         test(404, OperationOutcome.class, "Practitioner/{id}", testIds.unknown()));
   }
 
   @Test
-  public void local() {
-    assumeEnvironmentIn(Environment.LOCAL);
-    verifier.verifyAll(
+  public void search() {
+    verifyAll(
         test(200, Practitioner.Bundle.class, "Practitioner?_id={id}", testIds.practitioner()),
         test(
             200,
@@ -35,13 +42,5 @@ public class PractitionerIT {
             p -> p.entry().isEmpty(),
             "Practitioner?_id={id}",
             testIds.unknown()));
-  }
-
-  @Test
-  public void malformed() {
-    assumeEnvironmentIn(Environment.LOCAL);
-    verifier.verifyAll(
-        test(400, OperationOutcome.class, "Practitioner/"),
-        test(400, OperationOutcome.class, "Practitioner?nonsense=abc"));
   }
 }

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerRoleIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerRoleIT.java
@@ -1,6 +1,5 @@
 package gov.va.api.health.dataquery.tests.r4;
 
-
 import gov.va.api.health.dataquery.tests.DataQueryResourceVerifier;
 import gov.va.api.health.dataquery.tests.TestIds;
 import gov.va.api.health.fhir.testsupport.ResourceVerifier;

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerRoleIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerRoleIT.java
@@ -1,13 +1,11 @@
 package gov.va.api.health.dataquery.tests.r4;
 
-import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentIn;
 
 import gov.va.api.health.dataquery.tests.DataQueryResourceVerifier;
 import gov.va.api.health.dataquery.tests.TestIds;
 import gov.va.api.health.fhir.testsupport.ResourceVerifier;
 import gov.va.api.health.r4.api.resources.OperationOutcome;
 import gov.va.api.health.r4.api.resources.PractitionerRole;
-import gov.va.api.health.sentinel.Environment;
 import lombok.experimental.Delegate;
 import org.junit.jupiter.api.Test;
 
@@ -27,13 +25,5 @@ public class PractitionerRoleIT {
             PractitionerRole.Bundle.class,
             "PractitionerRole?_id={id}",
             testIds.practitioner()));
-  }
-
-  @Test
-  public void malformed() {
-    assumeEnvironmentIn(Environment.LOCAL);
-    verifier.verifyAll(
-        test(400, OperationOutcome.class, "PractitionerRole/"),
-        test(400, OperationOutcome.class, "PractitionerRole?blah=123"));
   }
 }

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/ProcedureIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/ProcedureIT.java
@@ -1,6 +1,5 @@
 package gov.va.api.health.dataquery.tests.r4;
 
-import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentIn;
 import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentNotIn;
 
 import gov.va.api.health.dataquery.tests.DataQueryResourceVerifier;
@@ -18,17 +17,23 @@ public class ProcedureIT {
   TestIds testIds = DataQueryResourceVerifier.ids();
 
   @Test
-  public void advanced() {
-    assumeEnvironmentIn(Environment.LOCAL);
-    verifier.verifyAll(
-        test(200, Procedure.Bundle.class, "Procedure?_id={id}", testIds.procedure()),
-        test(404, OperationOutcome.class, "Procedure?_id={id}", testIds.unknown()),
-        test(200, Procedure.Bundle.class, "Procedure?identifier={id}", testIds.procedure()));
+  public void read() {
+    verifyAll(
+        test(200, Procedure.class, "Procedure/{id}", testIds.procedure()),
+        test(404, OperationOutcome.class, "Procedure/{id}", testIds.unknown()));
   }
 
   @Test
-  public void basic() {
-    verifier.verifyAll(
+  public void search() {
+    verifyAll(
+        test(200, Procedure.Bundle.class, "Procedure?_id={id}", testIds.procedure()),
+        test(
+            200,
+            Procedure.Bundle.class,
+            b -> b.entry().isEmpty(),
+            "Procedure?_id={id}",
+            testIds.unknown()),
+        test(200, Procedure.Bundle.class, "Procedure?identifier={id}", testIds.procedure()),
         test(
             200,
             Procedure.Bundle.class,
@@ -42,8 +47,6 @@ public class ProcedureIT {
             testIds.patient(),
             testIds.procedures().fromDate(),
             testIds.procedures().toDate()),
-        test(200, Procedure.class, "Procedure/{id}", testIds.procedure()),
-        test(404, OperationOutcome.class, "Procedure/{id}", testIds.unknown()),
         test(200, Procedure.Bundle.class, "Procedure?patient={patient}", testIds.patient()));
   }
 

--- a/data-query/pom.xml
+++ b/data-query/pom.xml
@@ -8,7 +8,7 @@
     <relativePath/>
   </parent>
   <artifactId>data-query</artifactId>
-  <version>3.0.139-SNAPSHOT</version>
+  <version>3.0.139</version>
   <packaging>jar</packaging>
   <properties>
     <datamart-starter.version>2.0.1</datamart-starter.version>

--- a/data-query/pom.xml
+++ b/data-query/pom.xml
@@ -8,7 +8,7 @@
     <relativePath/>
   </parent>
   <artifactId>data-query</artifactId>
-  <version>3.0.139</version>
+  <version>3.0.140-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
     <datamart-starter.version>2.0.1</datamart-starter.version>

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/config/PatientRegistrationConfig.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/config/PatientRegistrationConfig.java
@@ -4,12 +4,15 @@ import gov.va.api.health.dataquery.patientregistration.PatientRegistrar;
 import gov.va.api.health.dataquery.patientregistration.PatientRegistrationFilter;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
+@Slf4j
 @Configuration
 @ComponentScan(basePackages = {"gov.va.api.health.dataquery.patientregistration"})
 public class PatientRegistrationConfig {
@@ -18,6 +21,7 @@ public class PatientRegistrationConfig {
   FilterRegistrationBean<PatientRegistrationFilter> patientRegistrationFilter(
       @Autowired PatientRegistrar registrar) {
     var registration = new FilterRegistrationBean<PatientRegistrationFilter>();
+    registration.setOrder(1);
     registration.setFilter(PatientRegistrationFilter.builder().registrar(registrar).build());
     registration.addUrlPatterns("/dstu2/Patient/*", "/stu3/Patient/*", "/r4/Patient/*");
     registration.addUrlPatterns("/dstu2/Patient", "/stu3/Patient", "/r4/Patient");
@@ -32,6 +36,7 @@ public class PatientRegistrationConfig {
                                     + pattern))
             .collect(Collectors.toList());
     urlPatternsWithLeadingPaths.forEach(registration::addUrlPatterns);
+    log.info("PatientRegistrationFilter enabled with priority {}", registration.getOrder());
     return registration;
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/config/PatientRegistrationConfig.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/config/PatientRegistrationConfig.java
@@ -4,7 +4,6 @@ import gov.va.api.health.dataquery.patientregistration.PatientRegistrar;
 import gov.va.api.health.dataquery.patientregistration.PatientRegistrationFilter;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/R4Controllers.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/R4Controllers.java
@@ -1,21 +1,42 @@
 package gov.va.api.health.dataquery.service.controller;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+
 import gov.va.api.health.r4.api.bundle.AbstractBundle;
 import gov.va.api.health.r4.api.bundle.AbstractEntry;
 import gov.va.api.health.r4.api.resources.Resource;
+import java.util.List;
 import java.util.function.Function;
+import org.springframework.util.MultiValueMap;
 
 public class R4Controllers {
 
   /** . */
   public static <R extends Resource, E extends AbstractEntry<R>, B extends AbstractBundle<E>>
-      B searchById(String id, Function<String, R> read, Function<R, B> toBundle) {
+      B searchById(
+          MultiValueMap<String, String> parameters,
+          Function<String, R> read,
+          BundleBuilder<R, E, B> toBundle) {
     R resource;
     try {
-      resource = read.apply(id);
+      resource = read.apply(Parameters.identifierOf(parameters));
     } catch (ResourceExceptions.NotFound e) {
       resource = null;
     }
-    return toBundle.apply(resource);
+    List<R> entries =
+        resource == null
+                || Parameters.pageOf(parameters) != 1
+                || Parameters.countOf(parameters) <= 0
+            ? emptyList()
+            : asList(resource);
+    int numberOfEntries = resource == null ? 0 : 1;
+    return toBundle.bundle(parameters, entries, numberOfEntries);
+  }
+
+  @FunctionalInterface
+  public interface BundleBuilder<
+      R extends Resource, E extends AbstractEntry<R>, B extends AbstractBundle<E>> {
+    B bundle(MultiValueMap<String, String> parameters, List<R> records, int totalRecords);
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/R4Controllers.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/R4Controllers.java
@@ -1,0 +1,21 @@
+package gov.va.api.health.dataquery.service.controller;
+
+import gov.va.api.health.r4.api.bundle.AbstractBundle;
+import gov.va.api.health.r4.api.bundle.AbstractEntry;
+import gov.va.api.health.r4.api.resources.Resource;
+import java.util.function.Function;
+
+public class R4Controllers {
+
+  /** . */
+  public static <R extends Resource, E extends AbstractEntry<R>, B extends AbstractBundle<E>>
+      B searchById(String id, Function<String, R> read, Function<R, B> toBundle) {
+    R resource;
+    try {
+      resource = read.apply(id);
+    } catch (ResourceExceptions.NotFound e) {
+      resource = null;
+    }
+    return toBundle.apply(resource);
+  }
+}

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/WitnessProtection.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/WitnessProtection.java
@@ -5,6 +5,7 @@ import gov.va.api.health.dataquery.service.controller.ResourceExceptions.NotFoun
 import gov.va.api.health.ids.api.IdentityService;
 import gov.va.api.health.ids.api.IdentitySubstitution;
 import gov.va.api.health.ids.api.ResourceIdentity;
+import gov.va.api.health.ids.client.IdEncoder;
 import gov.va.api.lighthouse.datamart.DatamartReference;
 import gov.va.api.lighthouse.datamart.HasReplaceableId;
 import gov.va.api.lighthouse.datamart.ResourceNameTranslation;
@@ -74,7 +75,11 @@ public class WitnessProtection extends IdentitySubstitution<DatamartReference> {
   /** Lookup and convert the given public ID to a CDW id. */
   @Loggable(arguments = false)
   public String toCdwId(String publicId) {
-    return privateIdOf("CDW", publicId).orElse(publicId);
+    try {
+      return privateIdOf("CDW", publicId).orElse(publicId);
+    } catch (IdEncoder.BadId whatever) {
+      return publicId;
+    }
   }
 
   /**

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/R4AllergyIntoleranceController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/R4AllergyIntoleranceController.java
@@ -8,6 +8,7 @@ import gov.va.api.health.dataquery.service.controller.IncludesIcnMajig;
 import gov.va.api.health.dataquery.service.controller.PageLinks;
 import gov.va.api.health.dataquery.service.controller.Parameters;
 import gov.va.api.health.dataquery.service.controller.R4Bundler;
+import gov.va.api.health.dataquery.service.controller.R4Controllers;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.r4.api.resources.AllergyIntolerance;
@@ -126,17 +127,14 @@ public class R4AllergyIntoleranceController {
             .add("page", page)
             .add("_count", count)
             .build();
-    AllergyIntolerance resource;
-    try {
-      resource = read(identifier);
-    } catch (ResourceExceptions.NotFound e) {
-      resource = null;
-    }
-    int totalRecords = resource == null ? 0 : 1;
-    if (resource == null || page != 1 || count <= 0) {
-      return bundle(parameters, emptyList(), totalRecords);
-    }
-    return bundle(parameters, asList(resource), totalRecords);
+    return R4Controllers.searchById(
+        identifier,
+        this::read,
+        r ->
+            bundle(
+                parameters,
+                r == null || page != 1 || count <= 0 ? emptyList() : asList(r),
+                r == null ? 0 : 1));
   }
 
   /** Search by patient. */

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/R4AllergyIntoleranceController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/R4AllergyIntoleranceController.java
@@ -1,6 +1,5 @@
 package gov.va.api.health.dataquery.service.controller.allergyintolerance;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
 import gov.va.api.health.dataquery.service.controller.CountParameter;
@@ -127,14 +126,7 @@ public class R4AllergyIntoleranceController {
             .add("page", page)
             .add("_count", count)
             .build();
-    return R4Controllers.searchById(
-        identifier,
-        this::read,
-        r ->
-            bundle(
-                parameters,
-                r == null || page != 1 || count <= 0 ? emptyList() : asList(r),
-                r == null ? 0 : 1));
+    return R4Controllers.searchById(parameters, this::read, this::bundle);
   }
 
   /** Search by patient. */

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/R4AllergyIntoleranceController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/R4AllergyIntoleranceController.java
@@ -126,7 +126,12 @@ public class R4AllergyIntoleranceController {
             .add("page", page)
             .add("_count", count)
             .build();
-    AllergyIntolerance resource = read(identifier);
+    AllergyIntolerance resource;
+    try {
+      resource = read(identifier);
+    } catch (ResourceExceptions.NotFound e) {
+      resource = null;
+    }
     int totalRecords = resource == null ? 0 : 1;
     if (resource == null || page != 1 || count <= 0) {
       return bundle(parameters, emptyList(), totalRecords);

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/R4DiagnosticReportController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/R4DiagnosticReportController.java
@@ -1,6 +1,5 @@
 package gov.va.api.health.dataquery.service.controller.diagnosticreport;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.apache.logging.log4j.util.Strings.isNotBlank;
 
@@ -208,13 +207,11 @@ public class R4DiagnosticReportController {
             .add("_count", count)
             .build();
     return R4Controllers.searchById(
-        identifier,
+        parameters,
         this::read,
-        r ->
-            bundle(
-                parameters,
-                r == null || page != 1 || count <= 0 ? emptyList() : asList(r),
-                r == null ? 0 : 1));
+        (R4Controllers.BundleBuilder<
+                DiagnosticReport, DiagnosticReport.Entry, DiagnosticReport.Bundle>)
+            this::bundle);
   }
 
   /** Search resource by patient. */

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/R4DiagnosticReportController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/R4DiagnosticReportController.java
@@ -1,5 +1,6 @@
 package gov.va.api.health.dataquery.service.controller.diagnosticreport;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.apache.logging.log4j.util.Strings.isNotBlank;
 
@@ -10,6 +11,7 @@ import gov.va.api.health.dataquery.service.controller.IncludesIcnMajig;
 import gov.va.api.health.dataquery.service.controller.PageLinks;
 import gov.va.api.health.dataquery.service.controller.Parameters;
 import gov.va.api.health.dataquery.service.controller.R4Bundler;
+import gov.va.api.health.dataquery.service.controller.R4Controllers;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.TokenParameter;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
@@ -205,17 +207,14 @@ public class R4DiagnosticReportController {
             .add("page", page)
             .add("_count", count)
             .build();
-    DiagnosticReport resource;
-    try {
-      resource = read(identifier);
-    } catch (ResourceExceptions.NotFound e) {
-      resource = null;
-    }
-    int totalRecords = resource == null ? 0 : 1;
-    if (resource == null || page != 1 || count <= 0) {
-      return bundle(parameters, emptyList(), totalRecords);
-    }
-    return bundle(parameters, List.of(resource), totalRecords);
+    return R4Controllers.searchById(
+        identifier,
+        this::read,
+        r ->
+            bundle(
+                parameters,
+                r == null || page != 1 || count <= 0 ? emptyList() : asList(r),
+                r == null ? 0 : 1));
   }
 
   /** Search resource by patient. */

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/R4DiagnosticReportController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/R4DiagnosticReportController.java
@@ -100,7 +100,7 @@ public class R4DiagnosticReportController {
         linkConfig, diagnosticReports, DiagnosticReport.Entry::new, DiagnosticReport.Bundle::new);
   }
 
-  DiagnosticReport.Bundle bundle(
+  DiagnosticReport.Bundle bundleEntities(
       MultiValueMap<String, String> parameters, Page<DiagnosticReportEntity> entitiesPage) {
     if (Parameters.countOf(parameters) <= 0) {
       return bundle(parameters, emptyList(), (int) entitiesPage.getTotalElements());
@@ -206,12 +206,7 @@ public class R4DiagnosticReportController {
             .add("page", page)
             .add("_count", count)
             .build();
-    return R4Controllers.searchById(
-        parameters,
-        this::read,
-        (R4Controllers.BundleBuilder<
-                DiagnosticReport, DiagnosticReport.Entry, DiagnosticReport.Bundle>)
-            this::bundle);
+    return R4Controllers.searchById(parameters, this::read, this::bundle);
   }
 
   /** Search resource by patient. */
@@ -232,7 +227,7 @@ public class R4DiagnosticReportController {
                 pageParam - 1,
                 countParam == 0 ? 1 : countParam,
                 DiagnosticReportEntity.naturalOrder()));
-    return bundle(parameters, entitiesPage);
+    return bundleEntities(parameters, entitiesPage);
   }
 
   /** Search resource by patient and category (and date if provided). */
@@ -266,7 +261,7 @@ public class R4DiagnosticReportController {
             .dates(date)
             .build();
     Page<DiagnosticReportEntity> entitiesPage = repository.findAll(spec, page(page, count));
-    return bundle(parameters, entitiesPage);
+    return bundleEntities(parameters, entitiesPage);
   }
 
   /** Search resources by patient and code (and date if provided). */
@@ -306,7 +301,7 @@ public class R4DiagnosticReportController {
             .dates(date)
             .build();
     Page<DiagnosticReportEntity> entitiesPage = repository.findAll(spec, page(page, count));
-    return bundle(parameters, entitiesPage);
+    return bundleEntities(parameters, entitiesPage);
   }
 
   /** Search resource by patient and status. */
@@ -345,7 +340,7 @@ public class R4DiagnosticReportController {
                 pageParam - 1,
                 countParam == 0 ? 1 : countParam,
                 DiagnosticReportEntity.naturalOrder()));
-    return bundle(parameters, entitiesPage);
+    return bundleEntities(parameters, entitiesPage);
   }
 
   private Boolean statusFinal(List<TokenParameter> codeTokens) {

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/R4DiagnosticReportController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/R4DiagnosticReportController.java
@@ -205,12 +205,17 @@ public class R4DiagnosticReportController {
             .add("page", page)
             .add("_count", count)
             .build();
-    DiagnosticReport dr = read(identifier);
-    int totalRecords = dr == null ? 0 : 1;
-    if (dr == null || page != 1 || count <= 0) {
+    DiagnosticReport resource;
+    try {
+      resource = read(identifier);
+    } catch (ResourceExceptions.NotFound e) {
+      resource = null;
+    }
+    int totalRecords = resource == null ? 0 : 1;
+    if (resource == null || page != 1 || count <= 0) {
       return bundle(parameters, emptyList(), totalRecords);
     }
-    return bundle(parameters, List.of(dr), totalRecords);
+    return bundle(parameters, List.of(resource), totalRecords);
   }
 
   /** Search resource by patient. */

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/Dstu2ImmunizationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/Dstu2ImmunizationController.java
@@ -168,7 +168,6 @@ public class Dstu2ImmunizationController {
       @RequestParam(value = "page", defaultValue = "1") @Min(1) int page,
       @CountParameter @Min(0) int count) {
     String icn = witnessProtection.toCdwId(patient);
-    log.info("Looking for {} ({})", patient, icn);
     return bundle(
         Parameters.builder().add("patient", patient).add("page", page).add("_count", count).build(),
         count,

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/R4ImmunizationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/R4ImmunizationController.java
@@ -164,7 +164,6 @@ public class R4ImmunizationController {
       @RequestParam(value = "page", defaultValue = "1") @Min(1) int page,
       @CountParameter @Min(0) int count) {
     String icn = witnessProtection.toCdwId(patient);
-    log.info("Looking for {} ({})", patient, icn);
     return bundle(
         Parameters.builder().add("patient", patient).add("page", page).add("_count", count).build(),
         count,

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/R4ImmunizationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/R4ImmunizationController.java
@@ -75,7 +75,7 @@ public class R4ImmunizationController {
         Immunization.Bundle::new);
   }
 
-  private Immunization.Bundle bundle(
+  private Immunization.Bundle bundleEntities(
       MultiValueMap<String, String> parameters, int count, Page<ImmunizationEntity> entities) {
     if (count == 0) {
       return bundle(parameters, emptyList(), (int) entities.getTotalElements());
@@ -149,11 +149,7 @@ public class R4ImmunizationController {
             .add("page", page)
             .add("_count", count)
             .build();
-    return R4Controllers.searchById(
-        parameters,
-        this::read,
-        (R4Controllers.BundleBuilder<Immunization, Immunization.Entry, Immunization.Bundle>)
-            this::bundle);
+    return R4Controllers.searchById(parameters, this::read, this::bundle);
   }
 
   /** Search by patient. */
@@ -163,7 +159,7 @@ public class R4ImmunizationController {
       @RequestParam(value = "page", defaultValue = "1") @Min(1) int page,
       @CountParameter @Min(0) int count) {
     String icn = witnessProtection.toCdwId(patient);
-    return bundle(
+    return bundleEntities(
         Parameters.builder().add("patient", patient).add("page", page).add("_count", count).build(),
         count,
         repository.findByIcn(

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/R4ImmunizationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/R4ImmunizationController.java
@@ -1,6 +1,5 @@
 package gov.va.api.health.dataquery.service.controller.immunization;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
 import gov.va.api.health.dataquery.service.controller.CountParameter;
@@ -151,13 +150,10 @@ public class R4ImmunizationController {
             .add("_count", count)
             .build();
     return R4Controllers.searchById(
-        identifier,
+        parameters,
         this::read,
-        r ->
-            bundle(
-                parameters,
-                r == null || page != 1 || count <= 0 ? emptyList() : asList(r),
-                r == null ? 0 : 1));
+        (R4Controllers.BundleBuilder<Immunization, Immunization.Entry, Immunization.Bundle>)
+            this::bundle);
   }
 
   /** Search by patient. */

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/R4ImmunizationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/R4ImmunizationController.java
@@ -8,6 +8,7 @@ import gov.va.api.health.dataquery.service.controller.IncludesIcnMajig;
 import gov.va.api.health.dataquery.service.controller.PageLinks;
 import gov.va.api.health.dataquery.service.controller.Parameters;
 import gov.va.api.health.dataquery.service.controller.R4Bundler;
+import gov.va.api.health.dataquery.service.controller.R4Controllers;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.r4.api.resources.Immunization;
@@ -149,17 +150,14 @@ public class R4ImmunizationController {
             .add("page", page)
             .add("_count", count)
             .build();
-    Immunization resource;
-    try {
-      resource = read(identifier);
-    } catch (ResourceExceptions.NotFound e) {
-      resource = null;
-    }
-    int totalRecords = resource == null ? 0 : 1;
-    if (resource == null || page != 1 || count <= 0) {
-      return bundle(parameters, emptyList(), totalRecords);
-    }
-    return bundle(parameters, asList(resource), totalRecords);
+    return R4Controllers.searchById(
+        identifier,
+        this::read,
+        r ->
+            bundle(
+                parameters,
+                r == null || page != 1 || count <= 0 ? emptyList() : asList(r),
+                r == null ? 0 : 1));
   }
 
   /** Search by patient. */

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/R4ImmunizationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/immunization/R4ImmunizationController.java
@@ -149,7 +149,12 @@ public class R4ImmunizationController {
             .add("page", page)
             .add("_count", count)
             .build();
-    Immunization resource = read(identifier);
+    Immunization resource;
+    try {
+      resource = read(identifier);
+    } catch (ResourceExceptions.NotFound e) {
+      resource = null;
+    }
     int totalRecords = resource == null ? 0 : 1;
     if (resource == null || page != 1 || count <= 0) {
       return bundle(parameters, emptyList(), totalRecords);

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/location/R4LocationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/location/R4LocationController.java
@@ -67,7 +67,7 @@ public class R4LocationController {
         Location.Bundle::new);
   }
 
-  private Location.Bundle bundle(
+  private Location.Bundle bundleEntities(
       MultiValueMap<String, String> parameters, int count, Page<LocationEntity> entitiesPage) {
     if (count == 0) {
       return bundle(parameters, emptyList(), (int) entitiesPage.getTotalElements());
@@ -141,7 +141,7 @@ public class R4LocationController {
             .postalCode(postalCode)
             .build();
     Page<LocationEntity> entitiesPage = repository.findAll(spec, page(page, count));
-    return bundle(parameters, count, entitiesPage);
+    return bundleEntities(parameters, count, entitiesPage);
   }
 
   /** Search for resource by _id. */
@@ -165,10 +165,7 @@ public class R4LocationController {
             .add("page", page)
             .add("_count", count)
             .build();
-    return R4Controllers.searchById(
-        parameters,
-        this::read,
-        (R4Controllers.BundleBuilder<Location, Location.Entry, Location.Bundle>) this::bundle);
+    return R4Controllers.searchById(parameters, this::read, this::bundle);
   }
 
   /** Search for resource by name. */
@@ -180,6 +177,6 @@ public class R4LocationController {
     MultiValueMap<String, String> parameters =
         Parameters.builder().add("name", name).add("page", page).add("_count", count).build();
     Page<LocationEntity> entitiesPage = repository.findByName(name, page(page, count));
-    return bundle(parameters, count, entitiesPage);
+    return bundleEntities(parameters, count, entitiesPage);
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/location/R4LocationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/location/R4LocationController.java
@@ -8,6 +8,7 @@ import gov.va.api.health.dataquery.service.controller.IncludesIcnMajig;
 import gov.va.api.health.dataquery.service.controller.PageLinks;
 import gov.va.api.health.dataquery.service.controller.Parameters;
 import gov.va.api.health.dataquery.service.controller.R4Bundler;
+import gov.va.api.health.dataquery.service.controller.R4Controllers;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.r4.api.resources.Location;
@@ -164,12 +165,10 @@ public class R4LocationController {
             .add("page", page)
             .add("_count", count)
             .build();
-    Location resource = read(publicId);
-    List<Location> records = resource == null ? emptyList() : List.of(resource);
-    if (count == 0) {
-      return bundle(parameters, emptyList(), records.size());
-    }
-    return bundle(parameters, records, records.size());
+    return R4Controllers.searchById(
+        parameters,
+        this::read,
+        (R4Controllers.BundleBuilder<Location, Location.Entry, Location.Bundle>) this::bundle);
   }
 
   /** Search for resource by name. */

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medication/R4MedicationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medication/R4MedicationController.java
@@ -1,5 +1,6 @@
 package gov.va.api.health.dataquery.service.controller.medication;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
 import gov.va.api.health.dataquery.service.controller.CountParameter;
@@ -7,6 +8,7 @@ import gov.va.api.health.dataquery.service.controller.IncludesIcnMajig;
 import gov.va.api.health.dataquery.service.controller.PageLinks;
 import gov.va.api.health.dataquery.service.controller.Parameters;
 import gov.va.api.health.dataquery.service.controller.R4Bundler;
+import gov.va.api.health.dataquery.service.controller.R4Controllers;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.r4.api.resources.Medication;
@@ -97,16 +99,16 @@ public class R4MedicationController {
       @RequestParam("_id") String id,
       @RequestParam(value = "page", defaultValue = "1") @Min(1) int page,
       @CountParameter @Min(0) int count) {
-    Medication resource;
-    try {
-      resource = read(id);
-    } catch (ResourceExceptions.NotFound e) {
-      resource = null;
-    }
-    return bundle(
-        Parameters.builder().add("identifier", id).add("page", page).add("_count", count).build(),
-        resource == null || count == 0 ? emptyList() : List.of(resource),
-        resource == null ? 0 : 1);
+    MultiValueMap<String, String> parameters =
+        Parameters.builder().add("identifier", id).add("page", page).add("_count", count).build();
+    return R4Controllers.searchById(
+        id,
+        this::read,
+        r ->
+            bundle(
+                parameters,
+                r == null || page != 1 || count <= 0 ? emptyList() : asList(r),
+                r == null ? 0 : 1));
   }
 
   /** Search by Identifier. */

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medication/R4MedicationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medication/R4MedicationController.java
@@ -1,8 +1,5 @@
 package gov.va.api.health.dataquery.service.controller.medication;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-
 import gov.va.api.health.dataquery.service.controller.CountParameter;
 import gov.va.api.health.dataquery.service.controller.IncludesIcnMajig;
 import gov.va.api.health.dataquery.service.controller.PageLinks;
@@ -101,14 +98,7 @@ public class R4MedicationController {
       @CountParameter @Min(0) int count) {
     MultiValueMap<String, String> parameters =
         Parameters.builder().add("identifier", id).add("page", page).add("_count", count).build();
-    return R4Controllers.searchById(
-        id,
-        this::read,
-        r ->
-            bundle(
-                parameters,
-                r == null || page != 1 || count <= 0 ? emptyList() : asList(r),
-                r == null ? 0 : 1));
+    return R4Controllers.searchById(parameters, this::read, this::bundle);
   }
 
   /** Search by Identifier. */

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medication/R4MedicationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medication/R4MedicationController.java
@@ -97,7 +97,12 @@ public class R4MedicationController {
       @RequestParam("_id") String id,
       @RequestParam(value = "page", defaultValue = "1") @Min(1) int page,
       @CountParameter @Min(0) int count) {
-    Medication resource = read(id);
+    Medication resource;
+    try {
+      resource = read(id);
+    } catch (ResourceExceptions.NotFound e) {
+      resource = null;
+    }
     return bundle(
         Parameters.builder().add("identifier", id).add("page", page).add("_count", count).build(),
         resource == null || count == 0 ? emptyList() : List.of(resource),

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/Dstu2MedicationOrderController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationorder/Dstu2MedicationOrderController.java
@@ -155,7 +155,6 @@ public class Dstu2MedicationOrderController {
       @RequestParam(value = "page", defaultValue = "1") @Min(1) int page,
       @CountParameter @Min(0) int count) {
     String icn = witnessProtection.toCdwId(patient);
-    log.info("Looking for {} ({})", patient, icn);
     return bundle(
         Parameters.builder().add("patient", patient).add("page", page).add("_count", count).build(),
         count,

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationrequest/R4MedicationRequestController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationrequest/R4MedicationRequestController.java
@@ -1,6 +1,7 @@
 package gov.va.api.health.dataquery.service.controller.medicationrequest;
 
 import static gov.va.api.health.autoconfig.logging.LogSanitizer.sanitize;
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
 import gov.va.api.health.dataquery.service.controller.CountParameter;
@@ -8,6 +9,7 @@ import gov.va.api.health.dataquery.service.controller.IncludesIcnMajig;
 import gov.va.api.health.dataquery.service.controller.PageLinks;
 import gov.va.api.health.dataquery.service.controller.Parameters;
 import gov.va.api.health.dataquery.service.controller.R4Bundler;
+import gov.va.api.health.dataquery.service.controller.R4Controllers;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dataquery.service.controller.medicationorder.DatamartMedicationOrder;
@@ -252,17 +254,14 @@ public class R4MedicationRequestController {
       @CountParameter @Min(0) int count) {
     MultiValueMap<String, String> parameters =
         Parameters.builder().add("identifier", id).add("page", page).add("_count", count).build();
-    MedicationRequest resource;
-    try {
-      resource = read(id);
-    } catch (ResourceExceptions.NotFound e) {
-      resource = null;
-    }
-    int totalRecords = resource == null ? 0 : 1;
-    if (resource == null || page != 1 || count <= 0) {
-      return bundle(parameters, emptyList(), totalRecords);
-    }
-    return bundle(parameters, List.of(resource), totalRecords);
+    return R4Controllers.searchById(
+        id,
+        this::read,
+        r ->
+            bundle(
+                parameters,
+                r == null || page != 1 || count <= 0 ? emptyList() : asList(r),
+                r == null ? 0 : 1));
   }
 
   /** Search by patient. */

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationrequest/R4MedicationRequestController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationrequest/R4MedicationRequestController.java
@@ -1,7 +1,6 @@
 package gov.va.api.health.dataquery.service.controller.medicationrequest;
 
 import static gov.va.api.health.autoconfig.logging.LogSanitizer.sanitize;
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
 import gov.va.api.health.dataquery.service.controller.CountParameter;
@@ -255,13 +254,11 @@ public class R4MedicationRequestController {
     MultiValueMap<String, String> parameters =
         Parameters.builder().add("identifier", id).add("page", page).add("_count", count).build();
     return R4Controllers.searchById(
-        id,
+        parameters,
         this::read,
-        r ->
-            bundle(
-                parameters,
-                r == null || page != 1 || count <= 0 ? emptyList() : asList(r),
-                r == null ? 0 : 1));
+        (R4Controllers.BundleBuilder<
+                MedicationRequest, MedicationRequest.Entry, ? extends MedicationRequest.Bundle>)
+            this::bundle);
   }
 
   /** Search by patient. */

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationrequest/R4MedicationRequestController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationrequest/R4MedicationRequestController.java
@@ -252,7 +252,12 @@ public class R4MedicationRequestController {
       @CountParameter @Min(0) int count) {
     MultiValueMap<String, String> parameters =
         Parameters.builder().add("identifier", id).add("page", page).add("_count", count).build();
-    MedicationRequest resource = read(id);
+    MedicationRequest resource;
+    try {
+      resource = read(id);
+    } catch (ResourceExceptions.NotFound e) {
+      resource = null;
+    }
     int totalRecords = resource == null ? 0 : 1;
     if (resource == null || page != 1 || count <= 0) {
       return bundle(parameters, emptyList(), totalRecords);

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationstatement/Dstu2MedicationStatementController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/medicationstatement/Dstu2MedicationStatementController.java
@@ -164,7 +164,6 @@ public class Dstu2MedicationStatementController {
       @RequestParam(value = "page", defaultValue = "1") @Min(1) int page,
       @CountParameter @Min(0) int count) {
     String icn = witnessProtection.toCdwId(patient);
-    log.info("Looking for {} ({})", patient, icn);
     return bundle(
         Parameters.builder().add("patient", patient).add("page", page).add("_count", count).build(),
         count,

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/procedure/R4ProcedureController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/procedure/R4ProcedureController.java
@@ -1,6 +1,5 @@
 package gov.va.api.health.dataquery.service.controller.procedure;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
 import gov.va.api.health.dataquery.service.controller.CountParameter;
@@ -124,14 +123,7 @@ public class R4ProcedureController {
             .add("page", page)
             .add("_count", count)
             .build();
-    return R4Controllers.searchById(
-        publicId,
-        id -> read(id, icnHeader),
-        r ->
-            bundle(
-                parameters,
-                r == null || page != 1 || count <= 0 ? emptyList() : asList(r),
-                r == null ? 0 : 1));
+    return R4Controllers.searchById(parameters, id -> read(id, icnHeader), this::bundle);
   }
 
   /** Search by Identifier. */

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/procedure/R4ProcedureController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/procedure/R4ProcedureController.java
@@ -8,6 +8,7 @@ import gov.va.api.health.dataquery.service.controller.IncludesIcnMajig;
 import gov.va.api.health.dataquery.service.controller.PageLinks;
 import gov.va.api.health.dataquery.service.controller.Parameters;
 import gov.va.api.health.dataquery.service.controller.R4Bundler;
+import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions.NotFound;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dataquery.service.controller.procedure.ProcedureRepository.PatientAndDateSpecification;
@@ -116,7 +117,12 @@ public class R4ProcedureController {
       @RequestParam("_id") String publicId,
       @RequestParam(value = "page", defaultValue = "1") @Min(1) int page,
       @CountParameter @Min(0) int count) {
-    Procedure resource = read(publicId, icnHeader);
+    Procedure resource;
+    try {
+      resource = read(publicId, icnHeader);
+    } catch (ResourceExceptions.NotFound e) {
+      resource = null;
+    }
     return bundle(
         Parameters.builder()
             .add("identifier", publicId)

--- a/local-dynamo-db
+++ b/local-dynamo-db
@@ -29,14 +29,15 @@ exit 1
 main() {
   local args
   if ! args=$(getopt \
-    -l "debug" \
-    -o "" -- "$@")
+    -l "debug,name:" \
+    -o "n:" -- "$@")
   then usage; fi
   eval set -- "$args"
   while true
   do
     case "$1" in
       --debug) DEBUG=true;;
+      -n|--name) CONTAINER_NAME="${2}";;
       --) shift; break;;
     esac
     shift

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>7.0.23</version>
   </parent>
   <artifactId>data-query-parent</artifactId>
-  <version>3.0.139</version>
+  <version>3.0.140-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>data-query-ids-mapping</module>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>7.0.23</version>
   </parent>
   <artifactId>data-query-parent</artifactId>
-  <version>3.0.139-SNAPSHOT</version>
+  <version>3.0.139</version>
   <packaging>pom</packaging>
   <modules>
     <module>data-query-ids-mapping</module>


### PR DESCRIPTION
# [API-6195](https://vajira.max.gov/browse/API-6195)
This updates all current R4 (not DSTU2) controllers to return an empty bundle for unknown ids in a search. IT's were also updated to avoid local only tests where possible.

After these changes:
```
$ git grep assumeEnvironmentIn | grep LOCAL
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/HealthCheckIT.java:    assumeEnvironmentIn(Environment.LOCAL);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/LatestResourceEtlStatusIT.java:    assumeEnvironmentIn(Environment.LOCAL);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/AllergyIntoleranceIT.java:    assumeEnvironmentIn(Environment.LOCAL);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/ConditionIT.java:    assumeEnvironmentIn(Environment.LOCAL);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/DiagnosticReportIT.java:    assumeEnvironmentIn(Environment.LOCAL);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/ImmunizationIT.java:    assumeEnvironmentIn(Environment.LOCAL);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/MedicationIT.java:    assumeEnvironmentIn(Environment.LOCAL);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/MedicationOrderIT.java:    assumeEnvironmentIn(Environment.LOCAL);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/MedicationStatementIT.java:    assumeEnvironmentIn(Environment.LOCAL);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/ObservationIT.java:    assumeEnvironmentIn(Environment.LOCAL);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/OrganizationIT.java:    assumeEnvironmentIn(Environment.LOCAL);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/OrganizationIT.java:    assumeEnvironmentIn(Environment.LOCAL);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/PatientIT.java:    assumeEnvironmentIn(Environment.LOCAL);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/PatientIT.java:    assumeEnvironmentIn(Environment.LOCAL);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/ProcedureIT.java:    assumeEnvironmentIn(Environment.LOCAL);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/dstu2/WellKnownIT.java:    assumeEnvironmentIn(Environment.LOCAL);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/AppointmentIT.java:    assumeEnvironmentIn(STAGING_LAB, LAB, LOCAL);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/AppointmentIT.java:    assumeEnvironmentIn(LOCAL, STAGING_LAB, LAB);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/AppointmentIT.java:    assumeEnvironmentIn(LOCAL);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PatientIT.java:    assumeEnvironmentIn(Environment.LOCAL);
data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PatientIT.java:    assumeEnvironmentIn(Environment.LOCAL);
```