### PR TITLE
Decreased tooLongAgo from 36 to 28

### DIFF
--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/etlstatus/LatestResourceEtlStatusController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/etlstatus/LatestResourceEtlStatusController.java
@@ -57,7 +57,7 @@ public class LatestResourceEtlStatusController {
 
   ResponseEntity<Health> resourceStatusHealth(Instant now) {
     hasCachedResourceStatus.set(true);
-    Instant tooLongAgo = now.minus(36, ChronoUnit.HOURS);
+    Instant tooLongAgo = now.minus(28, ChronoUnit.HOURS);
     Iterable<LatestResourceEtlStatusEntity> entities = repository.findAll();
     List<Health> statusDetails =
         Streams.stream(entities).map(e -> toHealth(e, tooLongAgo)).collect(Collectors.toList());


### PR DESCRIPTION
Decreasing time to allow alert to return during the day for data sources team to react more efficiently.