### PR TITLE
API-3084-update-search-capabilities

### DIFF
--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/AllergyIntoleranceIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/AllergyIntoleranceIT.java
@@ -8,6 +8,7 @@ import gov.va.api.health.fhir.testsupport.ResourceVerifier;
 import gov.va.api.health.r4.api.resources.AllergyIntolerance;
 import gov.va.api.health.r4.api.resources.OperationOutcome;
 import gov.va.api.health.sentinel.Environment;
+import java.util.function.Predicate;
 import lombok.experimental.Delegate;
 import org.junit.jupiter.api.Test;
 
@@ -15,6 +16,10 @@ public class AllergyIntoleranceIT {
   @Delegate ResourceVerifier verifier = DataQueryResourceVerifier.r4();
 
   TestIds testIds = DataQueryResourceVerifier.ids();
+
+  private Predicate<AllergyIntolerance.Bundle> bundleIsNotEmpty() {
+    return bundle -> !bundle.entry().isEmpty();
+  }
 
   @Test
   public void read() {
@@ -30,22 +35,25 @@ public class AllergyIntoleranceIT {
         test(
             200,
             AllergyIntolerance.Bundle.class,
+            bundleIsNotEmpty(),
             "AllergyIntolerance?_id={id}",
             testIds.allergyIntolerance()),
         test(
             200,
             AllergyIntolerance.Bundle.class,
-            b -> b.entry().isEmpty(),
+            bundleIsNotEmpty().negate(),
             "AllergyIntolerance?_id={id}",
             testIds.unknown()),
         test(
             200,
             AllergyIntolerance.Bundle.class,
+            bundleIsNotEmpty(),
             "AllergyIntolerance?identifier={id}",
             testIds.allergyIntolerance()),
         test(
             200,
             AllergyIntolerance.Bundle.class,
+            bundleIsNotEmpty(),
             "AllergyIntolerance?patient={patient}",
             testIds.patient()));
   }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/R4AllergyIntoleranceControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/allergyintolerance/R4AllergyIntoleranceControllerTest.java
@@ -58,7 +58,14 @@ public class R4AllergyIntoleranceControllerTest {
 
   @ParameterizedTest
   @ValueSource(
-      strings = {"?patient=p1&_id=123", "?patient=p1&identifier=123", "?_id=123&identifier=456"})
+      strings = {
+        "?patient=p1&_id=123",
+        "?patient=p1&identifier=123",
+        "?_id=123&identifier=456",
+        "?patient:RelatedPerson=p1",
+        "?patient=RelatedPerson/p1",
+        "?patient=http://fonzy.com/r4/RelatedPerson/p1"
+      })
   @SneakyThrows
   void invalidRequests(String query) {
     var request = requestFromUri("http://fonzy.com/r4/AllergyIntolerance" + query);
@@ -141,7 +148,15 @@ public class R4AllergyIntoleranceControllerTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"?_id=pd1", "?identifier=pd1", "?patient=p1"})
+  @ValueSource(
+      strings = {
+        "?_id=pd1",
+        "?identifier=pd1",
+        "?patient=p1",
+        "?patient=Patient/p1",
+        "?patient=http://fonzy.com/r4/Patient/p1",
+        "?patient:Patient=p1"
+      })
   void validRequests(String query) {
     when(ids.register(any()))
         .thenReturn(


### PR DESCRIPTION
# [API-3084](https://vajira.max.gov/browse/API-3084)
This updates the patient search functionality to be a reference instead of value. The search by patient and code functionality was pushed out of this task and into another because code is not a searchable column in the database.