### PR TITLE
API-6945-update-token-mappings

### DIFF
--- a/data-query/pom.xml
+++ b/data-query/pom.xml
@@ -19,7 +19,7 @@
     <mssql-jdbc.version>7.4.1.jre8</mssql-jdbc.version>
     <swagger-maven-plugin.version>2.1.7</swagger-maven-plugin.version>
     <talos.version>0.0.4</talos.version>
-    <vulcan.version>1.0.8</vulcan.version>
+    <vulcan.version>1.0.9</vulcan.version>
   </properties>
   <dependencies>
     <dependency>

--- a/data-query/pom.xml
+++ b/data-query/pom.xml
@@ -19,7 +19,7 @@
     <mssql-jdbc.version>7.4.1.jre8</mssql-jdbc.version>
     <swagger-maven-plugin.version>2.1.7</swagger-maven-plugin.version>
     <talos.version>0.0.4</talos.version>
-    <vulcan.version>1.0.9</vulcan.version>
+    <vulcan.version>1.0.10-SNAPSHOT</vulcan.version>
   </properties>
   <dependencies>
     <dependency>

--- a/data-query/pom.xml
+++ b/data-query/pom.xml
@@ -19,7 +19,7 @@
     <mssql-jdbc.version>7.4.1.jre8</mssql-jdbc.version>
     <swagger-maven-plugin.version>2.1.7</swagger-maven-plugin.version>
     <talos.version>0.0.4</talos.version>
-    <vulcan.version>1.0.10-SNAPSHOT</vulcan.version>
+    <vulcan.version>1.0.11</vulcan.version>
   </properties>
   <dependencies>
     <dependency>

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/condition/R4ConditionController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/condition/R4ConditionController.java
@@ -2,6 +2,7 @@ package gov.va.api.health.dataquery.service.controller.condition;
 
 import static gov.va.api.lighthouse.vulcan.Rules.ifParameter;
 import static gov.va.api.lighthouse.vulcan.Rules.parametersNeverSpecifiedTogether;
+import static gov.va.api.lighthouse.vulcan.Specifications.strings;
 import static gov.va.api.lighthouse.vulcan.Vulcan.returnNothing;
 
 import gov.va.api.health.dataquery.service.config.LinkProperties;
@@ -16,10 +17,8 @@ import gov.va.api.lighthouse.vulcan.Vulcan;
 import gov.va.api.lighthouse.vulcan.VulcanConfiguration;
 import gov.va.api.lighthouse.vulcan.mappings.Mappings;
 import gov.va.api.lighthouse.vulcan.mappings.TokenParameter;
-import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -174,13 +173,9 @@ public class R4ConditionController {
     return token
         .behavior()
         .onExplicitSystemAndAnyCode(
-            s -> {
-              var values =
-                  Arrays.stream(DatamartCondition.Category.values())
-                      .map(Enum::toString)
-                      .collect(Collectors.toList());
-              return Specifications.<ConditionEntity>selectInList("category", values);
-            })
+            s ->
+                Specifications.<ConditionEntity>selectInList(
+                    "category", strings(DatamartCondition.Category.class)))
         .onExplicitSystemAndExplicitCode(
             (s, c) ->
                 Specifications.<ConditionEntity>select("category", toDatamartCategoryValue(c)))
@@ -214,13 +209,9 @@ public class R4ConditionController {
     return token
         .behavior()
         .onExplicitSystemAndAnyCode(
-            s -> {
-              var codes =
-                  Arrays.stream(DatamartCondition.ClinicalStatus.values())
-                      .map(Enum::toString)
-                      .collect(Collectors.toList());
-              return Specifications.<ConditionEntity>selectInList("clinicalStatus", codes);
-            })
+            s ->
+                Specifications.<ConditionEntity>selectInList(
+                    "clinicalStatus", strings(DatamartCondition.ClinicalStatus.class)))
         .onExplicitSystemAndExplicitCode(
             (s, c) ->
                 Specifications.<ConditionEntity>select(

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/R4DiagnosticReportController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/R4DiagnosticReportController.java
@@ -3,6 +3,7 @@ package gov.va.api.health.dataquery.service.controller.diagnosticreport;
 import static gov.va.api.lighthouse.vulcan.Rules.atLeastOneParameterOf;
 import static gov.va.api.lighthouse.vulcan.Rules.ifParameter;
 import static gov.va.api.lighthouse.vulcan.Rules.parametersNeverSpecifiedTogether;
+import static gov.va.api.lighthouse.vulcan.Specifications.strings;
 import static gov.va.api.lighthouse.vulcan.Vulcan.returnNothing;
 
 import gov.va.api.health.dataquery.service.config.LinkProperties;
@@ -164,7 +165,7 @@ public class R4DiagnosticReportController {
         .onExplicitSystemAndAnyCode(
             s ->
                 Specifications.<DiagnosticReportEntity>selectInList(
-                    "category", Set.of(CategoryCode.CH.toString(), CategoryCode.MB.toString())))
+                    "category", strings(CategoryCode.CH, CategoryCode.MB)))
         .build()
         .execute();
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/R4DiagnosticReportController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/R4DiagnosticReportController.java
@@ -4,7 +4,6 @@ import static gov.va.api.lighthouse.vulcan.Rules.atLeastOneParameterOf;
 import static gov.va.api.lighthouse.vulcan.Rules.ifParameter;
 import static gov.va.api.lighthouse.vulcan.Rules.parametersNeverSpecifiedTogether;
 import static gov.va.api.lighthouse.vulcan.Vulcan.returnNothing;
-import static java.util.stream.Collectors.toList;
 
 import gov.va.api.health.dataquery.service.config.LinkProperties;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
@@ -14,13 +13,12 @@ import gov.va.api.health.dataquery.service.controller.vulcanizer.VulcanizedBundl
 import gov.va.api.health.dataquery.service.controller.vulcanizer.VulcanizedReader;
 import gov.va.api.health.dataquery.service.controller.vulcanizer.VulcanizedTransformation;
 import gov.va.api.health.r4.api.resources.DiagnosticReport;
+import gov.va.api.lighthouse.vulcan.Specifications;
 import gov.va.api.lighthouse.vulcan.Vulcan;
 import gov.va.api.lighthouse.vulcan.VulcanConfiguration;
 import gov.va.api.lighthouse.vulcan.mappings.Mappings;
 import gov.va.api.lighthouse.vulcan.mappings.ReferenceParameter;
 import gov.va.api.lighthouse.vulcan.mappings.TokenParameter;
-import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -29,6 +27,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -70,9 +69,10 @@ public class R4DiagnosticReportController {
                     this::referencePatientIsSupported,
                     this::referencePatientValues)
                 .dateAsInstant("date", "dateUtc")
-                .tokenList("code", this::tokenCodeIsSupported, this::tokenCodeValues)
-                .tokenList("category", this::tokenCategoryIsSupported, this::tokenCategoryValues)
-                .tokenList("status", this::tokenStatusIsSupported, this::tokenStatusValues)
+                .tokens("code", this::tokenCodeIsSupported, this::tokenCodeSpecifications)
+                .tokens(
+                    "category", this::tokenCategoryIsSupported, this::tokenCategorySpecification)
+                .tokens("status", this::tokenStatusIsSupported, this::tokenStatusSpecification)
                 .get())
         .defaultQuery(returnNothing())
         .rule(atLeastOneParameterOf("patient", "_id", "identifier"))
@@ -146,18 +146,27 @@ public class R4DiagnosticReportController {
     return true;
   }
 
-  Collection<String> tokenCategoryValues(TokenParameter token) {
+  Specification<DiagnosticReportEntity> tokenCategorySpecification(TokenParameter token) {
     return token
         .behavior()
-        .onExplicitSystemAndExplicitCode((s, c) -> CategoryCode.forFhirCategory(c))
-        .onAnySystemAndExplicitCode(CategoryCode::forFhirCategory)
-        .onNoSystemAndExplicitCode(CategoryCode::forFhirCategory)
-        .onExplicitSystemAndAnyCode(s -> Set.of(CategoryCode.CH, CategoryCode.MB))
+        .onExplicitSystemAndExplicitCode(
+            (s, c) ->
+                Specifications.<DiagnosticReportEntity>select(
+                    "category", CategoryCode.forFhirCategory(c).toString()))
+        .onAnySystemAndExplicitCode(
+            c ->
+                Specifications.<DiagnosticReportEntity>select(
+                    "category", CategoryCode.forFhirCategory(c).toString()))
+        .onNoSystemAndExplicitCode(
+            c ->
+                Specifications.<DiagnosticReportEntity>select(
+                    "category", CategoryCode.forFhirCategory(c).toString()))
+        .onExplicitSystemAndAnyCode(
+            s ->
+                Specifications.<DiagnosticReportEntity>selectInList(
+                    "category", Set.of(CategoryCode.CH.toString(), CategoryCode.MB.toString())))
         .build()
-        .execute()
-        .stream()
-        .map(CategoryCode::toString)
-        .collect(toList());
+        .execute();
   }
 
   boolean tokenCodeIsSupported(TokenParameter token) {
@@ -165,8 +174,12 @@ public class R4DiagnosticReportController {
         && !token.hasExplicitSystem();
   }
 
-  Collection<String> tokenCodeValues(TokenParameter token) {
-    return token.behavior().onAnySystemAndExplicitCode(List::of).build().execute();
+  Specification<DiagnosticReportEntity> tokenCodeSpecifications(TokenParameter token) {
+    return token
+        .behavior()
+        .onAnySystemAndExplicitCode(c -> Specifications.<DiagnosticReportEntity>select("code", c))
+        .build()
+        .execute();
   }
 
   boolean tokenStatusIsSupported(TokenParameter token) {
@@ -174,14 +187,14 @@ public class R4DiagnosticReportController {
         && (token.hasSupportedSystem(DR_STATUS_SYSTEM) || token.hasAnySystem());
   }
 
-  Collection<String> tokenStatusValues(TokenParameter token) {
+  Specification<DiagnosticReportEntity> tokenStatusSpecification(TokenParameter token) {
     /*
      * There are no values of status that are searchable. All diagnostic reports are "final", if the
      * token is supported, then we effectively "select all". By returning no values, the token
      * mapping will abstain from contributing to any additional where clauses. We rely on `patient`
      * clause to find all records for this patient.
      */
-    return List.of();
+    return null;
   }
 
   VulcanizedTransformation<DiagnosticReportEntity, DatamartDiagnosticReport, DiagnosticReport>

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/R4ObservationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/R4ObservationController.java
@@ -11,19 +11,21 @@ import gov.va.api.health.dataquery.service.controller.vulcanizer.VulcanizedBundl
 import gov.va.api.health.dataquery.service.controller.vulcanizer.VulcanizedReader;
 import gov.va.api.health.dataquery.service.controller.vulcanizer.VulcanizedTransformation;
 import gov.va.api.health.r4.api.resources.Observation;
+import gov.va.api.lighthouse.vulcan.Specifications;
 import gov.va.api.lighthouse.vulcan.Vulcan;
 import gov.va.api.lighthouse.vulcan.VulcanConfiguration;
 import gov.va.api.lighthouse.vulcan.mappings.Mappings;
 import gov.va.api.lighthouse.vulcan.mappings.TokenParameter;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -58,8 +60,9 @@ public class R4ObservationController {
         .paging(linkProperties.pagingConfiguration("Observation", ObservationEntity.naturalOrder()))
         .mappings(
             Mappings.forEntity(ObservationEntity.class)
-                .tokenList("category", this::tokenCategoryIsSupported, this::tokenCategoryValues)
-                .tokenList("code", this::tokenCodeIsSupported, this::tokenCodeValues)
+                .tokens(
+                    "category", this::tokenCategoryIsSupported, this::tokenCategorySpecification)
+                .tokens("code", this::tokenCodeIsSupported, this::tokenCodeSpecification)
                 .dateAsInstant("date", "dateUtc")
                 .value("_id", "cdwId", witnessProtection::toCdwId)
                 .value("identifier", "cdwId", witnessProtection::toCdwId)
@@ -133,12 +136,16 @@ public class R4ObservationController {
         || (token.hasAnySystem() && codeIsSupported);
   }
 
-  Collection<String> tokenCategoryValues(TokenParameter token) {
+  private Specification<ObservationEntity> tokenCategorySpecification(TokenParameter token) {
     return token
         .behavior()
-        .onExplicitSystemAndAnyCode(s -> List.of("laboratory", "vital-signs"))
-        .onAnySystemAndExplicitCode(List::of)
-        .onExplicitSystemAndExplicitCode((s, c) -> List.of(c))
+        .onExplicitSystemAndAnyCode(
+            s ->
+                Specifications.<ObservationEntity>selectInList(
+                    "category", List.of("laboratory", "vital-signs")))
+        .onAnySystemAndExplicitCode(c -> Specifications.<ObservationEntity>select("category", c))
+        .onExplicitSystemAndExplicitCode(
+            (s, c) -> Specifications.<ObservationEntity>select("category", c))
         .build()
         .execute();
   }
@@ -147,19 +154,22 @@ public class R4ObservationController {
     return token.hasSupportedSystem(OBSERVATION_CODE_SYSTEM) || token.hasAnySystem();
   }
 
-  Collection<String> tokenCodeValues(TokenParameter token) {
+  Specification<ObservationEntity> tokenCodeSpecification(TokenParameter token) {
     return token
         .behavior()
         .onExplicitSystemAndAnyCode(
             s -> {
               if (OBSERVATION_CODE_SYSTEM.equals(s)) {
-                return List.of(ObservationRepository.ANY_CODE_VALUE);
+                return (Specification<ObservationEntity>)
+                    ObservationRepository.CodeSpecification.of(
+                        Set.of(ObservationRepository.ANY_CODE_VALUE));
               }
               throw new IllegalStateException(
                   "Unsupported Code System: " + s + " Cannot build ExplicitSystemSpecification.");
             })
-        .onExplicitSystemAndExplicitCode((s, c) -> List.of(c))
-        .onAnySystemAndExplicitCode(List::of)
+        .onExplicitSystemAndExplicitCode(
+            (s, c) -> Specifications.<ObservationEntity>select("code", c))
+        .onAnySystemAndExplicitCode(c -> Specifications.<ObservationEntity>select("code", c))
         .build()
         .execute();
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/R4ObservationController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/observation/R4ObservationController.java
@@ -2,6 +2,7 @@ package gov.va.api.health.dataquery.service.controller.observation;
 
 import static gov.va.api.lighthouse.vulcan.Rules.ifParameter;
 import static gov.va.api.lighthouse.vulcan.Rules.parametersNeverSpecifiedTogether;
+import static gov.va.api.lighthouse.vulcan.Specifications.strings;
 import static gov.va.api.lighthouse.vulcan.Vulcan.returnNothing;
 
 import gov.va.api.health.dataquery.service.config.LinkProperties;
@@ -16,7 +17,6 @@ import gov.va.api.lighthouse.vulcan.Vulcan;
 import gov.va.api.lighthouse.vulcan.VulcanConfiguration;
 import gov.va.api.lighthouse.vulcan.mappings.Mappings;
 import gov.va.api.lighthouse.vulcan.mappings.TokenParameter;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -142,7 +142,7 @@ public class R4ObservationController {
         .onExplicitSystemAndAnyCode(
             s ->
                 Specifications.<ObservationEntity>selectInList(
-                    "category", List.of("laboratory", "vital-signs")))
+                    "category", strings("laboratory", "vital-signs")))
         .onAnySystemAndExplicitCode(c -> Specifications.<ObservationEntity>select("category", c))
         .onExplicitSystemAndExplicitCode(
             (s, c) -> Specifications.<ObservationEntity>select("category", c))

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/R4DiagnosticReportControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/diagnosticreport/R4DiagnosticReportControllerTest.java
@@ -10,7 +10,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.base.Splitter;
 import gov.va.api.health.dataquery.service.config.LinkProperties;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
 import gov.va.api.health.dataquery.service.controller.diagnosticreport.DiagnosticReportSamples.DatamartV2;
@@ -160,32 +159,10 @@ class R4DiagnosticReportControllerTest {
   }
 
   @ParameterizedTest
-  @CsvSource({
-    "LAB,CH+MB",
-    "CH,CH",
-    "MB,MB",
-    "http://terminology.hl7.org/CodeSystem/v2-0074|LAB,CH+MB",
-    "http://terminology.hl7.org/CodeSystem/v2-0074|CH,CH",
-    "http://terminology.hl7.org/CodeSystem/v2-0074|MB,MB",
-    "http://terminology.hl7.org/CodeSystem/v2-0074|,CH+MB"
-  })
-  void tokenCategoryValues(String parameterValue, String expected) {
-    var token = TokenParameter.parse("category", parameterValue);
-    assertThat(controller().tokenCategoryValues(token))
-        .containsExactlyInAnyOrderElementsOf(Splitter.on('+').splitToList(expected));
-  }
-
-  @ParameterizedTest
   @CsvSource({"panel,true", "http://nope|panel,false", "|panel,false", "nope,false"})
   void tokenCodeIsSupported(String parameterValue, boolean expectedSupport) {
     var token = TokenParameter.parse("code", parameterValue);
     assertThat(controller().tokenCodeIsSupported(token)).isEqualTo(expectedSupport);
-  }
-
-  @Test
-  void tokenCodeValues() {
-    var token = TokenParameter.parse("code", "panel");
-    assertThat(controller().tokenCodeValues(token)).containsExactly("panel");
   }
 
   @ParameterizedTest
@@ -205,27 +182,23 @@ class R4DiagnosticReportControllerTest {
   @ParameterizedTest
   @ValueSource(
       strings = {
-        "final",
-        "http://hl7.org/fhir/diagnostic-report-status|final",
-      })
-  void tokenStatusValues(String parameterValue) {
-    var token = TokenParameter.parse("status", parameterValue);
-    assertThat(controller().tokenStatusValues(token)).isEmpty();
-  }
-
-  @ParameterizedTest
-  @ValueSource(
-      strings = {
         "?_id=pdr1",
         "?identifier=pdr1",
         "?patient=p1",
         "?patient=p1&category=LAB",
+        "?patient=p1&category=CH",
+        "?patient=p1&category=MB",
+        "?patient=p1&category=http://terminology.hl7.org/CodeSystem/v2-0074|LAB",
+        "?patient=p1&category=http://terminology.hl7.org/CodeSystem/v2-0074|CH",
+        "?patient=p1&category=http://terminology.hl7.org/CodeSystem/v2-0074|MB",
+        "?patient=p1&category=http://terminology.hl7.org/CodeSystem/v2-0074|",
         "?patient=p1&category=LAB&date=2005",
         "?patient=p1&category=LAB&date=gt2005&date=lt2006",
         "?patient=p1&code=panel",
         "?patient=p1&code=panel&date=2005",
         "?patient=p1&code=panel&date=gt2005&date=lt2006",
-        "?patient=p1&status=final"
+        "?patient=p1&status=final",
+        "?patient=p1&status=http://hl7.org/fhir/diagnostic-report-status|final"
       })
   @SneakyThrows
   void validRequests(String query) {


### PR DESCRIPTION
# [API-6945](https://vajira.max.gov/browse/API-6945)
In support of https://github.com/department-of-veterans-affairs/lighthouse-vulcan/pull/14 , this PR updates the deprecated tokenCsvList mappings in data-query.