### PR TITLE
API-7137-static-refresh-it

### DIFF
--- a/data-query-tests/pom.xml
+++ b/data-query-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>test-starter</artifactId>
-    <version>7.0.24</version>
+    <version>7.0.25</version>
     <relativePath/>
   </parent>
   <artifactId>data-query-tests</artifactId>

--- a/data-query-tests/src/main/docker/entrypoint.sh
+++ b/data-query-tests/src/main/docker/entrypoint.sh
@@ -156,6 +156,7 @@ setupForAutomation() {
 
   SYSTEM_PROPERTIES="-Dsentinel=$SENTINEL_ENV \
     -Daccess-token=$TOKEN \
+    -Dstatic-refresh-token=${STATIC_REFRESH_TOKEN} \
     -Draw-token=$RAW_TOKEN \
     -Dbulk-token=$BULK_TOKEN \
     -D${K8S_ENVIRONMENT}.user-password=$USER_PASSWORD \

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/StaticRefreshIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/StaticRefreshIT.java
@@ -1,0 +1,61 @@
+package gov.va.api.health.dataquery.tests;
+
+import static gov.va.api.health.sentinel.EnvironmentAssumptions.assumeEnvironmentNotIn;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import gov.va.api.health.sentinel.Environment;
+import gov.va.api.health.sentinel.selenium.VaOauthRobot;
+import java.util.Set;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Slf4j
+public class StaticRefreshIT {
+
+  private static Stream<Arguments> staticTokenRefresh() {
+    return Stream.of(
+        arguments(SystemDefinitions.systemDefinition().dstu2DataQuery().urlWithApiPath()),
+        arguments(SystemDefinitions.systemDefinition().r4DataQuery().urlWithApiPath()));
+  }
+
+  private VaOauthRobot.Configuration configuration(String tokenUrl) {
+    return VaOauthRobot.Configuration.builder()
+        .authorization(
+            VaOauthRobot.Configuration.Authorization.builder()
+                .authorizeUrl("not-used")
+                .redirectUrl("not-used")
+                .clientId("not-used")
+                .clientSecret("not-used")
+                .state("not-used")
+                .aud("not-used")
+                .scopes(Set.of("not-used"))
+                .build())
+        .tokenUrl(tokenUrl)
+        .user(
+            VaOauthRobot.Configuration.UserCredentials.builder()
+                .id("not-used")
+                .password("not-used")
+                .build())
+        .build();
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void staticTokenRefresh(String tokenUrlBasePath) {
+    assumeEnvironmentNotIn(Environment.LOCAL);
+    var tokenUrl = tokenUrlBasePath + "token";
+    log.info("Verify token refresh at {}", tokenUrl);
+    var robot = VaOauthRobot.of(configuration(tokenUrl));
+    VaOauthRobot.TokenExchange tokenToRefresh =
+        VaOauthRobot.TokenExchange.builder()
+            .patient(DataQueryResourceVerifier.ids().patient())
+            .refreshToken(System.getProperty("static-refresh-token"))
+            .build();
+    var newToken = robot.refreshUserAccessToken(tokenToRefresh, false);
+    assertThat(newToken.isError()).isFalse();
+  }
+}


### PR DESCRIPTION
# [API-7137](https://vajira.max.gov/browse/API-7137)
Uses the refreshUserAccessToken method in health-apis-parent to perform a static refresh for both the dstu2 and r4 token endpoints.