### PR TITLE
API-5012: update appointmentType system value

### DIFF
--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/appointment/R4AppointmentTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/appointment/R4AppointmentTransformer.java
@@ -37,7 +37,7 @@ final class R4AppointmentTransformer {
         .coding(
             List.of(
                 Coding.builder()
-                    .system("http://terminology.hl7.org/CodeSystem/v2-0276")
+                    .system("http://www.va.gov/Terminology/VistADefinedTerms/2.98-9.5")
                     .display(maybeAppointmentType.get())
                     .build()))
         .text(maybeAppointmentType.get())

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/appointment/AppointmentSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/appointment/AppointmentSamples.java
@@ -174,7 +174,7 @@ public class AppointmentSamples {
           .coding(
               List.of(
                   Coding.builder()
-                      .system("http://terminology.hl7.org/CodeSystem/v2-0276")
+                      .system("http://www.va.gov/Terminology/VistADefinedTerms/2.98-9.5")
                       .display("WALKIN")
                       .build()))
           .text("WALKIN")


### PR DESCRIPTION
This PR updates the R4 `Appointment.appointmentType` system value being emitted to use the VistA-specific identifier.