### PR TITLE
Add identifier search to R4 Practitioner

### DIFF
--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerIT.java
@@ -30,6 +30,24 @@ public class PractitionerIT {
             Practitioner.Bundle.class,
             p -> p.entry().isEmpty(),
             "Practitioner?_id={id}",
-            testIds.unknown()));
+            testIds.unknown()),
+        test(
+            200, Practitioner.Bundle.class, "Practitioner?identifier={id}", testIds.practitioner()),
+        test(
+            200,
+            Practitioner.Bundle.class,
+            "Practitioner?identifier={npi}",
+            testIds.practitioners().npi()),
+        test(
+            200,
+            Practitioner.Bundle.class,
+            "Practitioner?identifier=http://hl7.org/fhir/sid/us-npi|{npi}",
+            testIds.practitioners().npi()),
+        test(
+            200,
+            Practitioner.Bundle.class,
+            p -> p.entry().isEmpty(),
+            "Practitioner?identifier=http://hl7.org/fhir/sid/us-npi|{id}",
+            testIds.practitioner()));
   }
 }

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerIT.java
@@ -31,23 +31,52 @@ public class PractitionerIT {
             p -> p.entry().isEmpty(),
             "Practitioner?_id={id}",
             testIds.unknown()),
+        // any system with valid id
         test(
             200, Practitioner.Bundle.class, "Practitioner?identifier={id}", testIds.practitioner()),
+        // any system with valid npi
         test(
             200,
             Practitioner.Bundle.class,
             "Practitioner?identifier={npi}",
             testIds.practitioners().npi()),
+        // any system with unknown id
+        test(
+            200,
+            Practitioner.Bundle.class,
+            p -> p.entry().isEmpty(),
+            "Practitioner?identifier={id}",
+            testIds.unknown()),
+        // npi system with valid npi
         test(
             200,
             Practitioner.Bundle.class,
             "Practitioner?identifier=http://hl7.org/fhir/sid/us-npi|{npi}",
             testIds.practitioners().npi()),
+        // npi system with valid I2
         test(
             200,
             Practitioner.Bundle.class,
             p -> p.entry().isEmpty(),
             "Practitioner?identifier=http://hl7.org/fhir/sid/us-npi|{id}",
-            testIds.practitioner()));
+            testIds.practitioner()),
+        // npi system with unknown value
+        test(
+            200,
+            Practitioner.Bundle.class,
+            "Practitioner?identifier=http://hl7.org/fhir/sid/us-npi|{npi}",
+            testIds.unknown()),
+        // npi system with any code
+        test(
+            200,
+            Practitioner.Bundle.class,
+            "Practitioner?identifier=http://hl7.org/fhir/sid/us-npi|"),
+        // empty system with valid npi
+        test(
+            200,
+            Practitioner.Bundle.class,
+            p -> p.entry().isEmpty(),
+            "Practitioner?identifier=|{npi}",
+            testIds.unknown()));
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/R4PractitionerController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/R4PractitionerController.java
@@ -12,9 +12,12 @@ import gov.va.api.health.dataquery.service.controller.vulcanizer.VulcanizedBundl
 import gov.va.api.health.dataquery.service.controller.vulcanizer.VulcanizedReader;
 import gov.va.api.health.dataquery.service.controller.vulcanizer.VulcanizedTransformation;
 import gov.va.api.health.r4.api.resources.Practitioner;
+import gov.va.api.lighthouse.vulcan.Specifications;
+import gov.va.api.lighthouse.vulcan.SystemIdFields;
 import gov.va.api.lighthouse.vulcan.Vulcan;
 import gov.va.api.lighthouse.vulcan.VulcanConfiguration;
 import gov.va.api.lighthouse.vulcan.mappings.Mappings;
+import gov.va.api.lighthouse.vulcan.mappings.TokenParameter;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -25,6 +28,7 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -40,6 +44,8 @@ import org.springframework.web.bind.annotation.RestController;
     produces = {"application/json", "application/fhir+json"})
 @AllArgsConstructor(onConstructor_ = @Autowired)
 public class R4PractitionerController {
+  private static final String PRACTITIONER_IDENTIFIER_SYSTEM_NPI = "http://hl7.org/fhir/sid/us-npi";
+
   private final LinkProperties linkProperties;
 
   private PractitionerRepository repository;
@@ -53,9 +59,13 @@ public class R4PractitionerController {
         .mappings(
             Mappings.forEntity(PractitionerEntity.class)
                 .value("_id", "cdwId", witnessProtection::toCdwId)
+                .tokens(
+                    "identifier",
+                    this::tokenIdentifierIsSupported,
+                    this::tokenIdentifierSpecification)
                 .get())
         .defaultQuery(returnNothing())
-        .rules(List.of(atLeastOneParameterOf("_id")))
+        .rules(List.of(atLeastOneParameterOf("_id", "identifier")))
         .build();
   }
 
@@ -110,6 +120,27 @@ public class R4PractitionerController {
                 .linkProperties(linkProperties)
                 .build())
         .build();
+  }
+
+  private boolean tokenIdentifierIsSupported(TokenParameter token) {
+    return token.hasSupportedSystem(PRACTITIONER_IDENTIFIER_SYSTEM_NPI) || token.hasAnySystem();
+  }
+
+  private Specification<PractitionerEntity> tokenIdentifierSpecification(TokenParameter token) {
+    var systemMappings =
+        SystemIdFields.forEntity(PractitionerEntity.class)
+            .parameterName("identifier")
+            .add(PRACTITIONER_IDENTIFIER_SYSTEM_NPI, "npi");
+    return token
+        .behavior()
+        .onAnySystemAndExplicitCode(
+            code ->
+                Specifications.<PractitionerEntity>select("cdwId", witnessProtection.toCdwId(code))
+                    .or(Specifications.select("npi", code)))
+        .onExplicitSystemAndAnyCode(systemMappings.matchSystemOnly())
+        .onExplicitSystemAndExplicitCode(systemMappings.matchSystemAndCode())
+        .build()
+        .execute();
   }
 
   VulcanizedTransformation<PractitionerEntity, DatamartPractitioner, Practitioner>

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/R4PractitionerControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/R4PractitionerControllerTest.java
@@ -53,7 +53,7 @@ public class R4PractitionerControllerTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"", "?identifier=123", "?invalid=request"})
+  @ValueSource(strings = {"", "?invalid=request"})
   @SneakyThrows
   void invalidRequest(String query) {
     var r = requestFromUri("http://fonzy.com/r4/Practitioner" + query);
@@ -150,7 +150,13 @@ public class R4PractitionerControllerTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"?_id=pr1"})
+  @ValueSource(
+      strings = {
+        "?_id=pr1",
+        "?identifier=pr1",
+        "?identifier=http://hl7.org/fhir/sid/us-npi|",
+        "?identifier=http://hl7.org/fhir/sid/us-npi|123"
+      })
   @SneakyThrows
   void validRequest(String query) {
     when(ids.register(any())).thenReturn(List.of(registration("pr1", "ppr1")));


### PR DESCRIPTION
Adds identifier search support to R4 Practitioner Controller. Supports `npi` and `I2` searches.