### PR TITLE
API-7988: STU3 Practitioner identifier and specialty fix

### DIFF
--- a/data-query-tests/pom.xml
+++ b/data-query-tests/pom.xml
@@ -11,7 +11,7 @@
   <version>3.0.197-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
-    <fhir-resources.version>7.0.8-SNAPSHOT</fhir-resources.version>
+    <fhir-resources.version>8.0.0</fhir-resources.version>
     <health-apis-ids.version>3.0.3</health-apis-ids.version>
     <selenium.version>3.141.59</selenium.version>
     <sentinel.skipLaunch>false</sentinel.skipLaunch>

--- a/data-query-tests/pom.xml
+++ b/data-query-tests/pom.xml
@@ -11,7 +11,7 @@
   <version>3.0.197-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
-    <fhir-resources.version>7.0.7</fhir-resources.version>
+    <fhir-resources.version>7.0.8-SNAPSHOT</fhir-resources.version>
     <health-apis-ids.version>3.0.3</health-apis-ids.version>
     <selenium.version>3.141.59</selenium.version>
     <sentinel.skipLaunch>false</sentinel.skipLaunch>

--- a/data-query/pom.xml
+++ b/data-query/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <datamart-starter.version>3.0.0</datamart-starter.version>
     <fall-risk.version>2.0.0</fall-risk.version>
-    <fhir-resources.version>7.0.7</fhir-resources.version>
+    <fhir-resources.version>7.0.8-SNAPSHOT</fhir-resources.version>
     <guava.version>30.1.1-jre</guava.version>
     <health-apis-ids.version>4.0.3</health-apis-ids.version>
     <mssql-jdbc.version>9.2.1.jre15</mssql-jdbc.version>

--- a/data-query/pom.xml
+++ b/data-query/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <datamart-starter.version>3.0.0</datamart-starter.version>
     <fall-risk.version>2.0.0</fall-risk.version>
-    <fhir-resources.version>7.0.8-SNAPSHOT</fhir-resources.version>
+    <fhir-resources.version>8.0.0</fhir-resources.version>
     <guava.version>30.1.1-jre</guava.version>
     <health-apis-ids.version>4.0.3</health-apis-ids.version>
     <mssql-jdbc.version>9.2.1.jre15</mssql-jdbc.version>

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/location/Stu3LocationTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/location/Stu3LocationTransformer.java
@@ -7,6 +7,7 @@ import static java.util.Arrays.asList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import gov.va.api.health.dataquery.service.controller.EnumSearcher;
+import gov.va.api.health.stu3.api.datatypes.Address;
 import gov.va.api.health.stu3.api.datatypes.CodeableConcept;
 import gov.va.api.health.stu3.api.datatypes.Coding;
 import gov.va.api.health.stu3.api.datatypes.ContactPoint;
@@ -24,14 +25,14 @@ import org.apache.commons.lang3.StringUtils;
 final class Stu3LocationTransformer {
   @NonNull private final DatamartLocation datamart;
 
-  static Location.LocationAddress address(DatamartLocation.Address address) {
+  static Address address(DatamartLocation.Address address) {
     if (address == null) {
       return null;
     }
     if (allBlank(address.line1(), address.city(), address.state(), address.postalCode())) {
       return null;
     }
-    return Location.LocationAddress.builder()
+    return Address.builder()
         .line(emptyToNull(asList(address.line1())))
         .city(address.city())
         .state(address.state())

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/organization/Stu3OrganizationTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/organization/Stu3OrganizationTransformer.java
@@ -8,7 +8,9 @@ import static gov.va.api.health.dataquery.service.controller.Transformers.isBlan
 import static java.util.Arrays.asList;
 
 import gov.va.api.health.dataquery.service.controller.EnumSearcher;
+import gov.va.api.health.stu3.api.datatypes.Address;
 import gov.va.api.health.stu3.api.datatypes.ContactPoint;
+import gov.va.api.health.stu3.api.datatypes.Identifier;
 import gov.va.api.health.stu3.api.resources.Organization;
 import java.util.List;
 import java.util.Objects;
@@ -23,7 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 final class Stu3OrganizationTransformer {
   @NonNull private final DatamartOrganization datamart;
 
-  static List<Organization.OrganizationAddress> addresses(DatamartOrganization.Address address) {
+  static List<Address> addresses(DatamartOrganization.Address address) {
     if (address == null
         || allBlank(
             address.line1(),
@@ -34,7 +36,7 @@ final class Stu3OrganizationTransformer {
       return null;
     }
     return asList(
-        Organization.OrganizationAddress.builder()
+        Address.builder()
             .line(emptyToNull(asList(address.line1(), address.line2())))
             .city(address.city())
             .state(address.state())
@@ -52,15 +54,12 @@ final class Stu3OrganizationTransformer {
             .build());
   }
 
-  static List<Organization.OrganizationIdentifier> identifier(Optional<String> npi) {
+  static List<Identifier> identifier(Optional<String> npi) {
     if (isBlank(npi)) {
       return null;
     }
     return asList(
-        Organization.OrganizationIdentifier.builder()
-            .system("http://hl7.org/fhir/sid/us-npi")
-            .value(npi.get())
-            .build());
+        Identifier.builder().system("http://hl7.org/fhir/sid/us-npi").value(npi.get()).build());
   }
 
   static ContactPoint telecom(DatamartOrganization.Telecom telecom) {

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Stu3PractitionerTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Stu3PractitionerTransformer.java
@@ -11,6 +11,8 @@ import static java.util.Collections.singletonList;
 import gov.va.api.health.dataquery.service.controller.EnumSearcher;
 import gov.va.api.health.stu3.api.datatypes.Address;
 import gov.va.api.health.stu3.api.datatypes.ContactPoint;
+import gov.va.api.health.stu3.api.datatypes.HumanName;
+import gov.va.api.health.stu3.api.datatypes.Identifier;
 import gov.va.api.health.stu3.api.resources.Practitioner;
 import java.time.LocalDate;
 import java.util.List;
@@ -51,21 +53,21 @@ public class Stu3PractitionerTransformer {
         source, gender -> EnumSearcher.of(Practitioner.Gender.class).find(gender.toString()));
   }
 
-  private static List<Practitioner.PractitionerIdentifier> identifiers(Optional<String> npi) {
+  private static List<Identifier> identifiers(Optional<String> npi) {
     // TODO is unknown the correct value to populate in case of missing NPI?
     return asList(
-        Practitioner.PractitionerIdentifier.builder()
+        Identifier.builder()
             .system("http://hl7.org/fhir/sid/us-npi")
             .value(npi.orElse("Unknown"))
             .build());
   }
 
-  static List<Practitioner.PractitionerHumanName> name(DatamartPractitioner.Name source) {
+  static List<HumanName> name(DatamartPractitioner.Name source) {
     if (source == null || isBlank(source.family())) {
       return null;
     }
     return List.of(
-        Practitioner.PractitionerHumanName.builder()
+        HumanName.builder()
             .family(source.family())
             .given(nameList(Optional.ofNullable(source.given())))
             .suffix(nameList(source.suffix()))

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Stu3PractitionerTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Stu3PractitionerTransformer.java
@@ -53,13 +53,10 @@ public class Stu3PractitionerTransformer {
   }
 
   private static List<Practitioner.PractitionerIdentifier> identifiers(Optional<String> npi) {
-    if (isBlank(npi)) {
-      return null;
-    }
     return asList(
         Practitioner.PractitionerIdentifier.builder()
             .system("http://hl7.org/fhir/sid/us-npi")
-            .value(npi.get())
+            .value(npi.orElse("Unknown"))
             .build());
   }
 

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Stu3PractitionerTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Stu3PractitionerTransformer.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.Builder;
-import org.apache.commons.lang3.BooleanUtils;
 
 /** Convert from datamart to STU3. */
 @Builder
@@ -61,16 +60,17 @@ public class Stu3PractitionerTransformer {
             .build());
   }
 
-  static Practitioner.PractitionerHumanName name(DatamartPractitioner.Name source) {
+  static List<Practitioner.PractitionerHumanName> name(DatamartPractitioner.Name source) {
     if (source == null || isBlank(source.family())) {
       return null;
     }
-    return Practitioner.PractitionerHumanName.builder()
-        .family(source.family())
-        .given(nameList(Optional.ofNullable(source.given())))
-        .suffix(nameList(source.suffix()))
-        .prefix(nameList(source.prefix()))
-        .build();
+    return List.of(
+        Practitioner.PractitionerHumanName.builder()
+            .family(source.family())
+            .given(nameList(Optional.ofNullable(source.given())))
+            .suffix(nameList(source.suffix()))
+            .prefix(nameList(source.prefix()))
+            .build());
   }
 
   static List<String> nameList(Optional<String> source) {
@@ -119,7 +119,7 @@ public class Stu3PractitionerTransformer {
     return Practitioner.builder()
         .id(datamart.cdwId())
         .resourceType("Practitioner")
-        .active(BooleanUtils.isTrue(datamart.active()))
+        .active(datamart.active())
         .telecom(telecoms())
         .address(addresses())
         .gender(gender(datamart.gender()))

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Stu3PractitionerTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Stu3PractitionerTransformer.java
@@ -53,6 +53,7 @@ public class Stu3PractitionerTransformer {
   }
 
   private static List<Practitioner.PractitionerIdentifier> identifiers(Optional<String> npi) {
+    // TODO is unknown the correct value to populate in case of missing NPI?
     return asList(
         Practitioner.PractitionerIdentifier.builder()
             .system("http://hl7.org/fhir/sid/us-npi")

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitionerrole/Stu3PractitionerRoleTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitionerrole/Stu3PractitionerRoleTransformer.java
@@ -4,6 +4,7 @@ import static gov.va.api.health.dataquery.service.controller.Stu3Transformers.as
 import static gov.va.api.health.dataquery.service.controller.Stu3Transformers.asReference;
 import static gov.va.api.health.dataquery.service.controller.Transformers.emptyToNull;
 import static gov.va.api.health.dataquery.service.controller.Transformers.isBlank;
+import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 
 import gov.va.api.health.dataquery.service.controller.practitioner.DatamartPractitioner;
@@ -28,7 +29,7 @@ final class Stu3PractitionerRoleTransformer {
     if (role.isEmpty()) {
       return null;
     }
-    return List.of(asCodeableConceptWrapping(role.get().role()));
+    return emptyToNull(asList(asCodeableConceptWrapping(role.get().role())));
   }
 
   static List<Reference> healthCareService(Optional<DatamartPractitioner.PractitionerRole> role) {
@@ -84,10 +85,11 @@ final class Stu3PractitionerRoleTransformer {
       return null;
     }
 
-    return role.get().specialty().stream()
-        .map(Stu3PractitionerRoleTransformer::specialty)
-        .filter(Objects::nonNull)
-        .collect(toList());
+    return emptyToNull(
+        role.get().specialty().stream()
+            .map(Stu3PractitionerRoleTransformer::specialty)
+            .filter(Objects::nonNull)
+            .collect(toList()));
   }
 
   static CodeableConcept specialty(DatamartPractitioner.PractitionerRole.Specialty dmSpecialty) {

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/location/LocationSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/location/LocationSamples.java
@@ -338,7 +338,7 @@ public class LocationSamples {
           .resourceType("Location")
           .id(id)
           .address(
-              gov.va.api.health.stu3.api.resources.Location.LocationAddress.builder()
+              gov.va.api.health.stu3.api.datatypes.Address.builder()
                   .line(asList(LOCATION_ADDRESS_STREET))
                   .city(LOCATION_ADDRESS_CITY)
                   .state(LOCATION_ADDRESS_STATE)

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/location/Stu3LocationTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/location/Stu3LocationTransformerTest.java
@@ -3,6 +3,7 @@ package gov.va.api.health.dataquery.service.controller.location;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import gov.va.api.health.stu3.api.datatypes.Address;
 import gov.va.api.health.stu3.api.datatypes.CodeableConcept;
 import gov.va.api.health.stu3.api.datatypes.Coding;
 import gov.va.api.health.stu3.api.datatypes.ContactPoint;
@@ -25,26 +26,21 @@ public class Stu3LocationTransformerTest {
         .isNull();
     assertThat(
             Stu3LocationTransformer.address(DatamartLocation.Address.builder().line1("w").build()))
-        .isEqualTo(Location.LocationAddress.builder().line(asList("w")).text("w").build());
+        .isEqualTo(Address.builder().line(asList("w")).text("w").build());
     assertThat(
             Stu3LocationTransformer.address(DatamartLocation.Address.builder().city("x").build()))
-        .isEqualTo(Location.LocationAddress.builder().city("x").text("x").build());
+        .isEqualTo(Address.builder().city("x").text("x").build());
     assertThat(
             Stu3LocationTransformer.address(DatamartLocation.Address.builder().state("y").build()))
-        .isEqualTo(Location.LocationAddress.builder().state("y").text("y").build());
+        .isEqualTo(Address.builder().state("y").text("y").build());
     assertThat(
             Stu3LocationTransformer.address(
                 DatamartLocation.Address.builder().postalCode("z").build()))
-        .isEqualTo(Location.LocationAddress.builder().postalCode("z").text("z").build());
+        .isEqualTo(Address.builder().postalCode("z").text("z").build());
     assertThat(
             Stu3LocationTransformer.address(
                 DatamartLocation.Address.builder().line1("w").postalCode("z").build()))
-        .isEqualTo(
-            Location.LocationAddress.builder()
-                .line(asList("w"))
-                .postalCode("z")
-                .text("w z")
-                .build());
+        .isEqualTo(Address.builder().line(asList("w")).postalCode("z").text("w z").build());
     assertThat(
             Stu3LocationTransformer.address(
                 DatamartLocation.Address.builder()
@@ -54,7 +50,7 @@ public class Stu3LocationTransformerTest {
                     .postalCode("z")
                     .build()))
         .isEqualTo(
-            Location.LocationAddress.builder()
+            Address.builder()
                 .line(asList("w"))
                 .city("x")
                 .state("y")

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/organization/OrganizationSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/organization/OrganizationSamples.java
@@ -388,7 +388,7 @@ public class OrganizationSamples {
           .id(id)
           .identifier(
               asList(
-                  gov.va.api.health.stu3.api.resources.Organization.OrganizationIdentifier.builder()
+                  gov.va.api.health.stu3.api.datatypes.Identifier.builder()
                       .system("http://hl7.org/fhir/sid/us-npi")
                       .value("1205983228")
                       .build()))
@@ -426,7 +426,7 @@ public class OrganizationSamples {
                       .build()))
           .address(
               asList(
-                  gov.va.api.health.stu3.api.resources.Organization.OrganizationAddress.builder()
+                  gov.va.api.health.stu3.api.datatypes.Address.builder()
                       .line(asList(ORGANIZATION_ADDRESS_LINE_ONE, ORGANIZATION_ADDRESS_LINE_TWO))
                       .text(
                           Stream.of(

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/organization/Stu3OrganizationTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/organization/Stu3OrganizationTransformerTest.java
@@ -4,7 +4,9 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
+import gov.va.api.health.stu3.api.datatypes.Address;
 import gov.va.api.health.stu3.api.datatypes.ContactPoint;
+import gov.va.api.health.stu3.api.datatypes.Identifier;
 import gov.va.api.health.stu3.api.resources.Organization;
 import java.util.Optional;
 import lombok.SneakyThrows;
@@ -27,36 +29,27 @@ public class Stu3OrganizationTransformerTest {
     assertThat(
             Stu3OrganizationTransformer.addresses(
                 DatamartOrganization.Address.builder().line1("v").build()))
-        .isEqualTo(
-            asList(Organization.OrganizationAddress.builder().line(asList("v")).text("v").build()));
+        .isEqualTo(asList(Address.builder().line(asList("v")).text("v").build()));
     assertThat(
             Stu3OrganizationTransformer.addresses(
                 DatamartOrganization.Address.builder().line2("w").build()))
-        .isEqualTo(
-            asList(Organization.OrganizationAddress.builder().line(asList("w")).text("w").build()));
+        .isEqualTo(asList(Address.builder().line(asList("w")).text("w").build()));
     assertThat(
             Stu3OrganizationTransformer.addresses(
                 DatamartOrganization.Address.builder().city("x").build()))
-        .isEqualTo(asList(Organization.OrganizationAddress.builder().city("x").text("x").build()));
+        .isEqualTo(asList(Address.builder().city("x").text("x").build()));
     assertThat(
             Stu3OrganizationTransformer.addresses(
                 DatamartOrganization.Address.builder().state("y").build()))
-        .isEqualTo(asList(Organization.OrganizationAddress.builder().state("y").text("y").build()));
+        .isEqualTo(asList(Address.builder().state("y").text("y").build()));
     assertThat(
             Stu3OrganizationTransformer.addresses(
                 DatamartOrganization.Address.builder().postalCode("z").build()))
-        .isEqualTo(
-            asList(Organization.OrganizationAddress.builder().postalCode("z").text("z").build()));
+        .isEqualTo(asList(Address.builder().postalCode("z").text("z").build()));
     assertThat(
             Stu3OrganizationTransformer.addresses(
                 DatamartOrganization.Address.builder().line1("v").postalCode("z").build()))
-        .isEqualTo(
-            asList(
-                Organization.OrganizationAddress.builder()
-                    .line(asList("v"))
-                    .postalCode("z")
-                    .text("v z")
-                    .build()));
+        .isEqualTo(asList(Address.builder().line(asList("v")).postalCode("z").text("v z").build()));
     assertThat(
             Stu3OrganizationTransformer.addresses(
                 DatamartOrganization.Address.builder()
@@ -68,7 +61,7 @@ public class Stu3OrganizationTransformerTest {
                     .build()))
         .isEqualTo(
             asList(
-                Organization.OrganizationAddress.builder()
+                Address.builder()
                     .line(asList("1111 Test Ln", "Apt 1L"))
                     .city("Delta")
                     .state("ZZ")
@@ -93,7 +86,7 @@ public class Stu3OrganizationTransformerTest {
     assertThat(Stu3OrganizationTransformer.identifier(Optional.of("abc")))
         .isEqualTo(
             asList(
-                Organization.OrganizationIdentifier.builder()
+                Identifier.builder()
                     .system("http://hl7.org/fhir/sid/us-npi")
                     .value("abc")
                     .build()));

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/PractitionerSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/PractitionerSamples.java
@@ -357,14 +357,14 @@ public class PractitionerSamples {
           .id(id)
           .identifier(
               singletonList(
-                  gov.va.api.health.stu3.api.resources.Practitioner.PractitionerIdentifier.builder()
+                  gov.va.api.health.stu3.api.datatypes.Identifier.builder()
                       .system("http://hl7.org/fhir/sid/us-npi")
                       .value("1234567")
                       .build()))
           .active(true)
           .name(
               List.of(
-                  gov.va.api.health.stu3.api.resources.Practitioner.PractitionerHumanName.builder()
+                  gov.va.api.health.stu3.api.datatypes.HumanName.builder()
                       .family("Joe")
                       .given(List.of("Johnson"))
                       .build()))

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/PractitionerSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/PractitionerSamples.java
@@ -363,10 +363,11 @@ public class PractitionerSamples {
                       .build()))
           .active(true)
           .name(
-              gov.va.api.health.stu3.api.resources.Practitioner.PractitionerHumanName.builder()
-                  .family("Joe")
-                  .given(List.of("Johnson"))
-                  .build())
+              List.of(
+                  gov.va.api.health.stu3.api.resources.Practitioner.PractitionerHumanName.builder()
+                      .family("Joe")
+                      .given(List.of("Johnson"))
+                      .build()))
           .gender(gov.va.api.health.stu3.api.resources.Practitioner.Gender.male)
           .birthDate("1970-11-14")
           .address(

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/Stu3PractitionerTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/Stu3PractitionerTransformerTest.java
@@ -2,6 +2,7 @@ package gov.va.api.health.dataquery.service.controller.practitioner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import gov.va.api.health.stu3.api.datatypes.Identifier;
 import gov.va.api.health.stu3.api.resources.Practitioner;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -24,7 +25,7 @@ public class Stu3PractitionerTransformerTest {
                 .resourceType("Practitioner")
                 .identifier(
                     List.of(
-                        Practitioner.PractitionerIdentifier.builder()
+                        Identifier.builder()
                             .system("http://hl7.org/fhir/sid/us-npi")
                             .value("Unknown")
                             .build()))

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/Stu3PractitionerTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/Stu3PractitionerTransformerTest.java
@@ -3,6 +3,7 @@ package gov.va.api.health.dataquery.service.controller.practitioner;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import gov.va.api.health.stu3.api.resources.Practitioner;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class Stu3PractitionerTransformerTest {
@@ -18,7 +19,16 @@ public class Stu3PractitionerTransformerTest {
                 .datamart(DatamartPractitioner.builder().build())
                 .build()
                 .toFhir())
-        .isEqualTo(Practitioner.builder().resourceType("Practitioner").build());
+        .isEqualTo(
+            Practitioner.builder()
+                .resourceType("Practitioner")
+                .identifier(
+                    List.of(
+                        Practitioner.PractitionerIdentifier.builder()
+                            .system("http://hl7.org/fhir/sid/us-npi")
+                            .value("Unknown")
+                            .build()))
+                .build());
   }
 
   @Test

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitionerrole/PractitionerRoleSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitionerrole/PractitionerRoleSamples.java
@@ -220,24 +220,50 @@ public class PractitionerRoleSamples {
                   .display("CHEYENNE VA MEDICAL")
                   .build())
           .code(
-              CodeableConcept.builder()
-                  .coding(
-                      asList(
-                          Coding.builder()
-                              .system("rpcmm")
-                              .code("37")
-                              .display("PSYCHOLOGIST")
-                              .build()))
-                  .build())
+              List.of(
+                  CodeableConcept.builder()
+                      .coding(
+                          asList(
+                              Coding.builder()
+                                  .system("rpcmm")
+                                  .code("37")
+                                  .display("PSYCHOLOGIST")
+                                  .build()))
+                      .build()))
           .specialty(
-              CodeableConcept.builder()
-                  .coding(
-                      List.of(
-                          Coding.builder()
-                              .system("http://nucc.org/provider-taxonomy")
-                              .code("207Q00000X")
-                              .build()))
-                  .build())
+              List.of(
+                  CodeableConcept.builder()
+                      .coding(
+                          List.of(
+                              Coding.builder()
+                                  .system("http://nucc.org/provider-taxonomy")
+                                  .code("V111500")
+                                  .build()))
+                      .build(),
+                  CodeableConcept.builder()
+                      .coding(
+                          List.of(
+                              Coding.builder()
+                                  .system("http://nucc.org/provider-taxonomy")
+                                  .code("V111000")
+                                  .build()))
+                      .build(),
+                  CodeableConcept.builder()
+                      .coding(
+                          List.of(
+                              Coding.builder()
+                                  .system("http://nucc.org/provider-taxonomy")
+                                  .code("V110900")
+                                  .build()))
+                      .build(),
+                  CodeableConcept.builder()
+                      .coding(
+                          List.of(
+                              Coding.builder()
+                                  .system("http://nucc.org/provider-taxonomy")
+                                  .code("207Q00000X")
+                                  .build()))
+                      .build()))
           .location(
               asList(
                   Reference.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitionerrole/Stu3PractitionerRoleTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitionerrole/Stu3PractitionerRoleTransformerTest.java
@@ -27,7 +27,7 @@ public class Stu3PractitionerRoleTransformerTest {
     assertThat(
             Stu3PractitionerRoleTransformer.specialty(
                 Optional.of(DatamartPractitioner.PractitionerRole.builder().build())))
-        .isNull();
+        .isEmpty();
 
     assertThat(Stu3PractitionerRoleTransformer.specialty(" ")).isNull();
 
@@ -65,14 +65,23 @@ public class Stu3PractitionerRoleTransformerTest {
                                     .build()))
                         .build())))
         .isEqualTo(
-            CodeableConcept.builder()
-                .coding(
-                    List.of(
-                        Coding.builder()
-                            .system("http://nucc.org/provider-taxonomy")
-                            .code("x2")
-                            .build()))
-                .build());
+            List.of(
+                CodeableConcept.builder()
+                    .coding(
+                        List.of(
+                            Coding.builder()
+                                .system("http://nucc.org/provider-taxonomy")
+                                .code("v1")
+                                .build()))
+                    .build(),
+                CodeableConcept.builder()
+                    .coding(
+                        List.of(
+                            Coding.builder()
+                                .system("http://nucc.org/provider-taxonomy")
+                                .code("x2")
+                                .build()))
+                    .build()));
 
     // if no x12 code, use va code
     assertThat(
@@ -82,22 +91,20 @@ public class Stu3PractitionerRoleTransformerTest {
                         .specialty(
                             asList(
                                 DatamartPractitioner.PractitionerRole.Specialty.builder()
-                                    .specialtyCode(Optional.of("s1"))
-                                    .build(),
-                                DatamartPractitioner.PractitionerRole.Specialty.builder()
                                     .vaCode(Optional.of("v2"))
                                     .specialtyCode(Optional.of("s2"))
                                     .build()))
                         .build())))
         .isEqualTo(
-            CodeableConcept.builder()
-                .coding(
-                    List.of(
-                        Coding.builder()
-                            .system("http://nucc.org/provider-taxonomy")
-                            .code("v2")
-                            .build()))
-                .build());
+            List.of(
+                CodeableConcept.builder()
+                    .coding(
+                        List.of(
+                            Coding.builder()
+                                .system("http://nucc.org/provider-taxonomy")
+                                .code("v2")
+                                .build()))
+                    .build()));
 
     // if no x12 code or va code, use specialty code
     assertThat(
@@ -112,13 +119,14 @@ public class Stu3PractitionerRoleTransformerTest {
                                     .build()))
                         .build())))
         .isEqualTo(
-            CodeableConcept.builder()
-                .coding(
-                    List.of(
-                        Coding.builder()
-                            .system("http://nucc.org/provider-taxonomy")
-                            .code("s2")
-                            .build()))
-                .build());
+            List.of(
+                CodeableConcept.builder()
+                    .coding(
+                        List.of(
+                            Coding.builder()
+                                .system("http://nucc.org/provider-taxonomy")
+                                .code("s2")
+                                .build()))
+                    .build()));
   }
 }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitionerrole/Stu3PractitionerRoleTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitionerrole/Stu3PractitionerRoleTransformerTest.java
@@ -27,7 +27,7 @@ public class Stu3PractitionerRoleTransformerTest {
     assertThat(
             Stu3PractitionerRoleTransformer.specialty(
                 Optional.of(DatamartPractitioner.PractitionerRole.builder().build())))
-        .isEmpty();
+        .isNull();
 
     assertThat(Stu3PractitionerRoleTransformer.specialty(" ")).isNull();
 


### PR DESCRIPTION
Avoid nulls for STU3 Practitioner Identifier and PractitionerRole Specialty.

A change to the practitioner name used in SystemDefinitions triggered a failure in STU3 PractitionerIT, as it caused the search to return more items. Some of these resources in the bundled were not in compliance with STU3 spec, causing the IT failures.

This PR addresses the STU3 spec issues.

Merge FHIR Resources PR first: https://github.com/department-of-veterans-affairs/health-apis-fhir-resources/pull/133