### PR TITLE
API-8037 disable practitioner system-only IT

### DIFF
--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerIT.java
@@ -85,7 +85,7 @@ public class PractitionerIT {
             "Practitioner?identifier=|{npi}",
             testIds.unknown()));
 
-    // time out:
+    // times out:
     // test(200,Practitioner.Bundle.class,bundleHasResults(),"Practitioner?identifier=http://hl7.org/fhir/sid/us-npi|")
   }
 

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerIT.java
@@ -1,6 +1,5 @@
 package gov.va.api.health.dataquery.tests.r4;
 
-
 import gov.va.api.health.dataquery.tests.DataQueryResourceVerifier;
 import gov.va.api.health.dataquery.tests.TestIds;
 import gov.va.api.health.fhir.testsupport.ResourceVerifier;
@@ -82,14 +81,12 @@ public class PractitionerIT {
         test(
             200,
             Practitioner.Bundle.class,
-            bundleHasResults(),
-            "Practitioner?identifier=http://hl7.org/fhir/sid/us-npi|"),
-        test(
-            200,
-            Practitioner.Bundle.class,
             bundleHasResults().negate(),
             "Practitioner?identifier=|{npi}",
             testIds.unknown()));
+
+    // time out:
+    // test(200,Practitioner.Bundle.class,bundleHasResults(),"Practitioner?identifier=http://hl7.org/fhir/sid/us-npi|")
   }
 
   @Test


### PR DESCRIPTION
All Practitioner ITs have been re-enabled, but `Practitioner?identifier=http://hl7.org/fhir/sid/us-npi|` does not finish and must stay disabled.

Follow-up to investigate: https://vajira.max.gov/browse/API-8040