### PR TITLE
API-8016 remove practitioner and location datamart reference defaulting

### DIFF
--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/location/LocationEntity.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/location/LocationEntity.java
@@ -3,7 +3,6 @@ package gov.va.api.health.dataquery.service.controller.location;
 import gov.va.api.health.dataquery.service.controller.DatamartSupport;
 import gov.va.api.lighthouse.datamart.DatamartEntity;
 import gov.va.api.lighthouse.datamart.Payload;
-import java.util.Optional;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -73,12 +72,7 @@ public class LocationEntity implements DatamartEntity {
   }
 
   DatamartLocation asDatamartLocation() {
-    DatamartLocation dm = toPayload().deserialize();
-    if (dm.managingOrganization() != null && dm.managingOrganization().type().isEmpty()) {
-      // Hack... make sure reference type is populated
-      dm.managingOrganization().type(Optional.of("Organization"));
-    }
-    return dm;
+    return toPayload().deserialize();
   }
 
   @Override

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/PractitionerEntity.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/PractitionerEntity.java
@@ -60,13 +60,7 @@ public class PractitionerEntity implements CompositeIdDatamartEntity {
 
   /** Deserialize payload. */
   public DatamartPractitioner asDatamartPractitioner() {
-    DatamartPractitioner dm = toPayload().deserialize();
-    dm.practitionerRole()
-        .ifPresent(
-            pr -> pr.managingOrganization().ifPresent(mo -> mo.typeIfMissing("Organization")));
-    dm.practitionerRole()
-        .ifPresent(pr -> pr.location().forEach(loc -> loc.typeIfMissing("Location")));
-    return dm;
+    return toPayload().deserialize();
   }
 
   @Override


### PR DESCRIPTION
Confirmed with @nmoisan that references in the `Practitioner` and `Location` datamart resources are now fully populated