### PR TITLE
API-3701: practitioner role search by practitioner identifer and name

### DIFF
--- a/data-query-tests/pom.xml
+++ b/data-query-tests/pom.xml
@@ -11,7 +11,7 @@
   <version>3.0.207-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
-    <fhir-resources.version>8.0.0</fhir-resources.version>
+    <fhir-resources.version>8.0.1</fhir-resources.version>
     <health-apis-ids.version>3.0.3</health-apis-ids.version>
     <selenium.version>3.141.59</selenium.version>
     <sentinel.skipLaunch>false</sentinel.skipLaunch>

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerIT.java
@@ -7,7 +7,6 @@ import gov.va.api.health.r4.api.resources.OperationOutcome;
 import gov.va.api.health.r4.api.resources.Practitioner;
 import java.util.function.Predicate;
 import lombok.experimental.Delegate;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
 public class PractitionerIT {
@@ -92,8 +91,8 @@ public class PractitionerIT {
   @Test
   void searchByName() {
     // Grab subset of family/given names for startsWith tests
-    String startFamily = StringUtils.substring(testIds.practitioners().family(), 0, 3);
-    String startGiven = StringUtils.substring(testIds.practitioners().given(), 0, 3);
+    String startFamily = testIds.practitioners().family().substring(0, 3);
+    String startGiven = testIds.practitioners().given().substring(0, 3);
     verifyAll(
         test(
             200,

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerRoleIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerRoleIT.java
@@ -20,11 +20,14 @@ public class PractitionerRoleIT {
   }
 
   @Test
-  void basic() {
+  void read() {
     verifier.verifyAll(
         test(200, PractitionerRole.class, "PractitionerRole/{id}", testIds.practitionerRole()),
-        test(404, OperationOutcome.class, "PractitionerRole/{id}", testIds.unknown()),
-        // search by _id
+        test(
+            404,
+            OperationOutcome.class,
+            "PractitionerRole/{id}",
+            testIds.unknown()), // search by _id
         test(
             200,
             PractitionerRole.Bundle.class,
@@ -121,6 +124,53 @@ public class PractitionerRoleIT {
             PractitionerRole.Bundle.class,
             bundleHasResults().negate(),
             "PractitionerRole?practitioner.name={family}",
+            testIds.unknown()));
+  }
+
+  @Test
+  void searchByPractitionerIdentifier() {
+    verifyAll(
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults(),
+            "PractitionerRole?practitioner.identifier={id}",
+            testIds.practitioner()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults(),
+            "PractitionerRole?practitioner.identifier={npi}",
+            testIds.practitioners().npi()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults().negate(),
+            "PractitionerRole?practitioner.identifier={id}",
+            testIds.unknown()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults(),
+            "PractitionerRole?practitioner.identifier=http://hl7.org/fhir/sid/us-npi|{npi}",
+            testIds.practitioners().npi()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults().negate(),
+            "PractitionerRole?practitioner.identifier=http://hl7.org/fhir/sid/us-npi|{id}",
+            testIds.practitioner()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults().negate(),
+            "PractitionerRole?practitioner.identifier=http://hl7.org/fhir/sid/us-npi|{npi}",
+            testIds.unknown()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults().negate(),
+            "PractitionerRole?practitioner.identifier=|{npi}",
             testIds.unknown()));
   }
 }

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerRoleIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerRoleIT.java
@@ -5,13 +5,19 @@ import gov.va.api.health.dataquery.tests.TestIds;
 import gov.va.api.health.fhir.testsupport.ResourceVerifier;
 import gov.va.api.health.r4.api.resources.OperationOutcome;
 import gov.va.api.health.r4.api.resources.PractitionerRole;
+import java.util.function.Predicate;
 import lombok.experimental.Delegate;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
 public class PractitionerRoleIT {
   @Delegate ResourceVerifier verifier = DataQueryResourceVerifier.r4();
 
   TestIds testIds = DataQueryResourceVerifier.ids();
+
+  static Predicate<PractitionerRole.Bundle> bundleHasResults() {
+    return bundle -> !bundle.entry().isEmpty();
+  }
 
   @Test
   void basic() {
@@ -24,5 +30,97 @@ public class PractitionerRoleIT {
             PractitionerRole.Bundle.class,
             "PractitionerRole?_id={id}",
             testIds.practitionerRole()));
+  }
+
+  @Test
+  void searchByName() {
+    // Grab subset of family/given names for startsWith tests
+    String startFamily = StringUtils.substring(testIds.practitioners().family(), 0, 3);
+    String startGiven = StringUtils.substring(testIds.practitioners().given(), 0, 3);
+    verifier.verifyAll(
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults(),
+            "PractitionerRole?practitioner.given={given}",
+            testIds.practitioners().given()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults(),
+            "PractitionerRole?practitioner.family={family}",
+            testIds.practitioners().family()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults(),
+            "PractitionerRole?practitioner.family:exact={family}",
+            testIds.practitioners().family()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults(),
+            "PractitionerRole?practitioner.name={given}",
+            testIds.practitioners().given()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults(),
+            "PractitionerRole?practitioner.name={family}",
+            testIds.practitioners().family()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults(),
+            "PractitionerRole?practitioner.name:exact={family}",
+            testIds.practitioners().family()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults(),
+            "PractitionerRole?practitioner.given={given}",
+            startGiven),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults(),
+            "PractitionerRole?practitioner.family={family}",
+            startFamily),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults(),
+            "PractitionerRole?practitioner.name={given}",
+            startGiven),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults(),
+            "PractitionerRole?practitioner.name={family}",
+            startFamily),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults().negate(),
+            "PractitionerRole?practitioner.given={given}",
+            testIds.unknown()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults().negate(),
+            "PractitionerRole?practitioner.family={family}",
+            testIds.unknown()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults().negate(),
+            "PractitionerRole?practitioner.name={given}",
+            testIds.unknown()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults().negate(),
+            "PractitionerRole?practitioner.name={family}",
+            testIds.unknown()));
   }
 }

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerRoleIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerRoleIT.java
@@ -45,24 +45,6 @@ public class PractitionerRoleIT {
             200,
             PractitionerRole.Bundle.class,
             bundleHasResults(),
-            "PractitionerRole?practitioner.given={given}",
-            testIds.practitioners().given()),
-        test(
-            200,
-            PractitionerRole.Bundle.class,
-            bundleHasResults(),
-            "PractitionerRole?practitioner.family={family}",
-            testIds.practitioners().family()),
-        test(
-            200,
-            PractitionerRole.Bundle.class,
-            bundleHasResults(),
-            "PractitionerRole?practitioner.family:exact={family}",
-            testIds.practitioners().family()),
-        test(
-            200,
-            PractitionerRole.Bundle.class,
-            bundleHasResults(),
             "PractitionerRole?practitioner.name={given}",
             testIds.practitioners().given()),
         test(
@@ -81,18 +63,6 @@ public class PractitionerRoleIT {
             200,
             PractitionerRole.Bundle.class,
             bundleHasResults(),
-            "PractitionerRole?practitioner.given={given}",
-            startGiven),
-        test(
-            200,
-            PractitionerRole.Bundle.class,
-            bundleHasResults(),
-            "PractitionerRole?practitioner.family={family}",
-            startFamily),
-        test(
-            200,
-            PractitionerRole.Bundle.class,
-            bundleHasResults(),
             "PractitionerRole?practitioner.name={given}",
             startGiven),
         test(
@@ -101,18 +71,6 @@ public class PractitionerRoleIT {
             bundleHasResults(),
             "PractitionerRole?practitioner.name={family}",
             startFamily),
-        test(
-            200,
-            PractitionerRole.Bundle.class,
-            bundleHasResults().negate(),
-            "PractitionerRole?practitioner.given={given}",
-            testIds.unknown()),
-        test(
-            200,
-            PractitionerRole.Bundle.class,
-            bundleHasResults().negate(),
-            "PractitionerRole?practitioner.family={family}",
-            testIds.unknown()),
         test(
             200,
             PractitionerRole.Bundle.class,

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerRoleIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerRoleIT.java
@@ -7,7 +7,6 @@ import gov.va.api.health.r4.api.resources.OperationOutcome;
 import gov.va.api.health.r4.api.resources.PractitionerRole;
 import java.util.function.Predicate;
 import lombok.experimental.Delegate;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
 public class PractitionerRoleIT {
@@ -38,8 +37,8 @@ public class PractitionerRoleIT {
   @Test
   void searchByName() {
     // Grab subset of family/given names for startsWith tests
-    String startFamily = StringUtils.substring(testIds.practitioners().family(), 0, 3);
-    String startGiven = StringUtils.substring(testIds.practitioners().given(), 0, 3);
+    String startFamily = testIds.practitioners().family().substring(0, 3);
+    String startGiven = testIds.practitioners().given().substring(0, 3);
     verifier.verifyAll(
         test(
             200,

--- a/data-query/pom.xml
+++ b/data-query/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <datamart-starter.version>3.0.0</datamart-starter.version>
     <fall-risk.version>2.0.0</fall-risk.version>
-    <fhir-resources.version>8.0.0</fhir-resources.version>
+    <fhir-resources.version>8.0.1</fhir-resources.version>
     <guava.version>30.1.1-jre</guava.version>
     <health-apis-ids.version>4.0.3</health-apis-ids.version>
     <mssql-jdbc.version>9.2.1.jre15</mssql-jdbc.version>

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitionerrole/R4PractitionerRoleController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitionerrole/R4PractitionerRoleController.java
@@ -92,15 +92,15 @@ public class R4PractitionerRoleController {
       String code) {
     Specification<PractitionerRoleEntity> npiSpec =
         Specifications.<PractitionerRoleEntity>select("npi", code);
-    try {
-      CompositeCdwId cdwId = CompositeCdwId.fromCdwId(witnessProtection.toCdwId(code));
+    var maybeCdwId = CompositeCdwIds.optionalFromCdwId(witnessProtection.toCdwId(code));
+    if (maybeCdwId.isPresent()) {
+      var cdwId = maybeCdwId.get();
       Specification<PractitionerRoleEntity> cdwIdSpec =
           Specifications.<PractitionerRoleEntity>select("practitionerIdNumber", cdwId.cdwIdNumber())
               .and(Specifications.select("practitionerResourceCode", cdwId.cdwIdResourceCode()));
       return npiSpec.or(cdwIdSpec);
-    } catch (IllegalArgumentException e) {
-      return npiSpec;
     }
+    return npiSpec;
   }
 
   private Map<String, ?> loadCdwId(String publicId) {

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitionerrole/R4PractitionerRoleController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitionerrole/R4PractitionerRoleController.java
@@ -69,22 +69,14 @@ public class R4PractitionerRoleController {
                     "practitioner.identifier",
                     this::tokenIdentifierIsSupported,
                     this::tokenIdentifierSpecification)
-                .string("practitioner.given", "givenName")
-                .string("practitioner.family", "familyName")
                 .string("practitioner.name", f -> Set.of("familyName", "givenName"))
                 .get())
         .defaultQuery(returnNothing())
         .rules(
             List.of(
-                atLeastOneParameterOf(
-                    "_id",
-                    "practitioner.identifier",
-                    "practitioner.given",
-                    "practitioner.family",
-                    "practitioner.name"),
-                parametersNeverSpecifiedTogether("_id", "practitioner.identifier"),
-                parametersNeverSpecifiedTogether("practitioner.name", "practitioner.given"),
-                parametersNeverSpecifiedTogether("practitioner.name", "practitioner.family")))
+                atLeastOneParameterOf("_id", "practitioner.identifier", "practitioner.name"),
+                parametersNeverSpecifiedTogether(
+                    "_id", "practitioner.identifier", "practitioner.name")))
         .build();
   }
 

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitionerrole/R4PractitionerRoleControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitionerrole/R4PractitionerRoleControllerTest.java
@@ -71,9 +71,9 @@ public class R4PractitionerRoleControllerTest {
       strings = {
         "",
         "?unknownparam=123",
-        "?_id=foo&practitioner.identifier=bar",
-        "?practitioner.name=harry&practitioner.family=potter",
-        "?practitioner.name=harry&practitioner.given=harry"
+        "?_id=foo&practitioner.identifier=123",
+        "?_id=foo&practitioner.identifier=123&practitioner.name=bar",
+        "?practitioner.identifier=123&practitioner.name=bar"
       })
   void invalidRequests(String query) {
     var r = requestFromUri("http://fonzy.com/r4/PractitionerRole" + query);
@@ -216,10 +216,7 @@ public class R4PractitionerRoleControllerTest {
         "?practitioner.identifier=111:S",
         "?practitioner.identifier=http://hl7.org/fhir/sid/us-npi|",
         "?practitioner.identifier=http://hl7.org/fhir/sid/us-npi|123",
-        "?practitioner.family=potter",
-        "?practitioner.given=harry",
         "?practitioner.name=harry",
-        "?practitioner.name=potter"
       })
   void validRequests(String query) {
     _registerMockIdentities(

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitionerrole/R4PractitionerRoleControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitionerrole/R4PractitionerRoleControllerTest.java
@@ -67,7 +67,13 @@ public class R4PractitionerRoleControllerTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"", "?unknownparam=123"})
+  @ValueSource(
+      strings = {
+        "",
+        "?unknownparam=123",
+        "?practitioner.name=harry&practitioner.family=potter",
+        "?practitioner.name=harry&practitioner.given=harry"
+      })
   void invalidRequests(String query) {
     var r = requestFromUri("http://fonzy.com/r4/PractitionerRole" + query);
     assertThatExceptionOfType(InvalidRequest.class).isThrownBy(() -> _controller().search(r));
@@ -203,7 +209,14 @@ public class R4PractitionerRoleControllerTest {
 
   @ParameterizedTest
   @SuppressWarnings("unchecked")
-  @ValueSource(strings = {"?_id=111:S"})
+  @ValueSource(
+      strings = {
+        "?_id=111:S",
+        "?practitioner.family=potter",
+        "?practitioner.given=harry",
+        "?practitioner.name=harry",
+        "?practitioner.name=potter"
+      })
   void validRequests(String query) {
     _registerMockIdentities(
         idReg("PRACTITIONER_ROLE", "I2-111", "111:P"),

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitionerrole/R4PractitionerRoleControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitionerrole/R4PractitionerRoleControllerTest.java
@@ -71,6 +71,7 @@ public class R4PractitionerRoleControllerTest {
       strings = {
         "",
         "?unknownparam=123",
+        "?_id=foo&practitioner.identifier=bar",
         "?practitioner.name=harry&practitioner.family=potter",
         "?practitioner.name=harry&practitioner.given=harry"
       })
@@ -211,7 +212,10 @@ public class R4PractitionerRoleControllerTest {
   @SuppressWarnings("unchecked")
   @ValueSource(
       strings = {
-        "?_id=111:S",
+        "?_id=111:P",
+        "?practitioner.identifier=111:S",
+        "?practitioner.identifier=http://hl7.org/fhir/sid/us-npi|",
+        "?practitioner.identifier=http://hl7.org/fhir/sid/us-npi|123",
         "?practitioner.family=potter",
         "?practitioner.given=harry",
         "?practitioner.name=harry",


### PR DESCRIPTION
Adds support to `R4PractitionerRoleController` for the search parameters:

- `practitioner.identifier` - allows for NPI or cdw id
- `practitioner.name`
