### PR TITLE
API-7562 use PractitionerRoleEntity for DSTU2 Practitioner

### DIFF
--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerController.java
@@ -85,11 +85,14 @@ public class Dstu2PractitionerController {
 
   List<PractitionerRoleEntity> findRolesById(String publicId) {
     String cdwId = witnessProtection.toCdwId(publicId);
-    if (!cdwId.endsWith(":S")) {
+    if (cdwId.length() <= 1 || cdwId.charAt(cdwId.length() - 2) != ':') {
       cdwId = cdwId + ":S";
     }
     return CompositeCdwIds.optionalFromCdwId(cdwId)
-        .map(id -> roleRepository.findByPractitionerIdNumber(id.cdwIdNumber()))
+        .map(
+            id ->
+                roleRepository.findByPractitionerIdNumberAndPractitionerResourceCode(
+                    id.cdwIdNumber(), id.cdwIdResourceCode()))
         .orElse(List.of());
   }
 

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerController.java
@@ -1,8 +1,8 @@
 package gov.va.api.health.dataquery.service.controller.practitioner;
 
 import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
 
-import gov.va.api.health.dataquery.service.config.LinkProperties;
 import gov.va.api.health.dataquery.service.controller.CompositeCdwIds;
 import gov.va.api.health.dataquery.service.controller.CountParameter;
 import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
@@ -15,16 +15,14 @@ import gov.va.api.health.dataquery.service.controller.practitionerrole.DatamartP
 import gov.va.api.health.dataquery.service.controller.practitionerrole.PractitionerRoleEntity;
 import gov.va.api.health.dataquery.service.controller.practitionerrole.PractitionerRoleRepository;
 import gov.va.api.health.dstu2.api.resources.Practitioner;
-import gov.va.api.lighthouse.datamart.CompositeCdwId;
-import lombok.AllArgsConstructor;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import static java.util.stream.Collectors.toList;
 import java.util.stream.Stream;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.constraints.Min;
+import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
@@ -120,9 +118,7 @@ public class Dstu2PractitionerController {
         resources,
         resource ->
             Stream.concat(
-                resource
-                    .practitionerRole()
-                    .stream()
+                resource.practitionerRole().stream()
                     .map(role -> role.managingOrganization().orElse(null)),
                 resource.practitionerRole().stream().flatMap(role -> role.location().stream())));
 

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerController.java
@@ -111,7 +111,7 @@ public class Dstu2PractitionerController {
     return entity.payload();
   }
 
-  private Collection<DatamartPractitioner> replaceReferences(
+  private void replaceReferences(
       Collection<DatamartPractitioner> resources,
       Collection<DatamartPractitionerRole> roleResources) {
     witnessProtection.registerAndUpdateReferences(
@@ -121,7 +121,6 @@ public class Dstu2PractitionerController {
                 resource.practitionerRole().stream()
                     .map(role -> role.managingOrganization().orElse(null)),
                 resource.practitionerRole().stream().flatMap(role -> role.location().stream())));
-
     witnessProtection.registerAndUpdateReferences(
         roleResources,
         resource ->
@@ -130,7 +129,7 @@ public class Dstu2PractitionerController {
                     resource.practitioner().orElse(null),
                     resource.managingOrganization().orElse(null)),
                 resource.location().stream()));
-    return resources;
+    return;
   }
 
   @GetMapping(params = {"_id"})

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerController.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerController.java
@@ -129,7 +129,6 @@ public class Dstu2PractitionerController {
                     resource.practitioner().orElse(null),
                     resource.managingOrganization().orElse(null)),
                 resource.location().stream()));
-    return;
   }
 
   @GetMapping(params = {"_id"})

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerTransformer.java
@@ -24,13 +24,15 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.Builder;
+import lombok.NonNull;
+
 import org.apache.commons.lang3.BooleanUtils;
 
 @Builder
 public class Dstu2PractitionerTransformer {
-  private final DatamartPractitioner datamart;
+  @NonNull private final DatamartPractitioner datamart;
 
-  private final List<DatamartPractitionerRole> datamartRoles;
+  @NonNull private final List<DatamartPractitionerRole> datamartRoles;
 
   static Address address(DatamartPractitioner.Address address) {
     if (address == null
@@ -136,7 +138,8 @@ public class Dstu2PractitionerTransformer {
 
   List<Practitioner.PractitionerRole> practitionerRoles() {
     return emptyToNull(
-        datamartRoles.stream()
+        datamartRoles
+            .stream()
             .filter(Objects::nonNull)
             .flatMap(dmRole -> dmRole.role().stream().map(r -> practitionerRole(dmRole, r)))
             .collect(toList()));

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerTransformer.java
@@ -25,7 +25,6 @@ import java.util.Objects;
 import java.util.Optional;
 import lombok.Builder;
 import lombok.NonNull;
-
 import org.apache.commons.lang3.BooleanUtils;
 
 @Builder
@@ -55,6 +54,11 @@ public class Dstu2PractitionerTransformer {
 
   static String birthDate(Optional<LocalDate> source) {
     return source.map(LocalDate::toString).orElse(null);
+  }
+
+  static Practitioner.Gender gender(DatamartPractitioner.Gender source) {
+    return convert(
+        source, gender -> EnumSearcher.of(Practitioner.Gender.class).find(gender.toString()));
   }
 
   static List<Reference> healthcareServices(Optional<String> service) {
@@ -131,15 +135,9 @@ public class Dstu2PractitionerTransformer {
     return emptyToNull(datamart.address().stream().map(adr -> address(adr)).collect(toList()));
   }
 
-  Practitioner.Gender gender(DatamartPractitioner.Gender source) {
-    return convert(
-        source, gender -> EnumSearcher.of(Practitioner.Gender.class).find(gender.toString()));
-  }
-
   List<Practitioner.PractitionerRole> practitionerRoles() {
     return emptyToNull(
-        datamartRoles
-            .stream()
+        datamartRoles.stream()
             .filter(Objects::nonNull)
             .flatMap(dmRole -> dmRole.role().stream().map(r -> practitionerRole(dmRole, r)))
             .collect(toList()));

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerTransformer.java
@@ -9,6 +9,7 @@ import static gov.va.api.health.dataquery.service.controller.Transformers.ifPres
 import static gov.va.api.health.dataquery.service.controller.Transformers.isBlank;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
+
 import gov.va.api.health.dataquery.service.controller.EnumSearcher;
 import gov.va.api.health.dataquery.service.controller.practitionerrole.DatamartPractitionerRole;
 import gov.va.api.health.dstu2.api.datatypes.Address;
@@ -94,7 +95,8 @@ public class Dstu2PractitionerTransformer {
     return Practitioner.PractitionerRole.builder()
         .managingOrganization(asReference(source.managingOrganization()))
         .role(asCodeableConceptWrapping(singleRole))
-        .location(emptyToNull(source.location().stream().map(loc -> asReference(loc)).collect(toList())))
+        .location(
+            emptyToNull(source.location().stream().map(loc -> asReference(loc)).collect(toList())))
         .healthcareService(healthcareServices(source.healthCareService()))
         .build();
   }
@@ -134,10 +136,9 @@ public class Dstu2PractitionerTransformer {
 
   List<Practitioner.PractitionerRole> practitionerRoles() {
     return emptyToNull(
-        datamartRoles
-            .stream()
+        datamartRoles.stream()
             .filter(Objects::nonNull)
-            .flatMap(dmRole -> dmRole.role().stream().map(aRole -> practitionerRole(dmRole, aRole)))
+            .flatMap(dmRole -> dmRole.role().stream().map(r -> practitionerRole(dmRole, r)))
             .collect(toList()));
   }
 

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitionerrole/PractitionerRoleRepository.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitionerrole/PractitionerRoleRepository.java
@@ -21,5 +21,6 @@ public interface PractitionerRoleRepository
 
   Page<PractitionerRoleEntity> findByNpi(String npi, Pageable pageable);
 
-  List<PractitionerRoleEntity> findByPractitionerIdNumber(BigInteger idNumber);
+  List<PractitionerRoleEntity> findByPractitionerIdNumberAndPractitionerResourceCode(
+      BigInteger idNumber, char practitionerResourceCode);
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitionerrole/PractitionerRoleRepository.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitionerrole/PractitionerRoleRepository.java
@@ -2,6 +2,10 @@ package gov.va.api.health.dataquery.service.controller.practitionerrole;
 
 import gov.va.api.health.autoconfig.logging.Loggable;
 import gov.va.api.lighthouse.datamart.CompositeCdwId;
+
+import java.math.BigInteger;
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -18,4 +22,6 @@ public interface PractitionerRoleRepository
       String familyName, String givenName, Pageable pageable);
 
   Page<PractitionerRoleEntity> findByNpi(String npi, Pageable pageable);
+
+  List<PractitionerRoleEntity> findByPractitionerIdNumber(BigInteger idNumber);
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitionerrole/PractitionerRoleRepository.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitionerrole/PractitionerRoleRepository.java
@@ -2,10 +2,8 @@ package gov.va.api.health.dataquery.service.controller.practitionerrole;
 
 import gov.va.api.health.autoconfig.logging.Loggable;
 import gov.va.api.lighthouse.datamart.CompositeCdwId;
-
 import java.math.BigInteger;
 import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerControllerTest.java
@@ -13,6 +13,7 @@ import gov.va.api.health.dataquery.service.controller.ConfigurableBaseUrlPageLin
 import gov.va.api.health.dataquery.service.controller.Dstu2Bundler;
 import gov.va.api.health.dataquery.service.controller.ResourceExceptions;
 import gov.va.api.health.dataquery.service.controller.WitnessProtection;
+import gov.va.api.health.dataquery.service.controller.practitionerrole.PractitionerRoleRepository;
 import gov.va.api.health.dstu2.api.bundle.BundleLink.LinkRelation;
 import gov.va.api.health.dstu2.api.resources.Practitioner;
 import gov.va.api.health.ids.api.IdentityService;
@@ -36,6 +37,8 @@ public class Dstu2PractitionerControllerTest {
 
   @Autowired PractitionerRepository repository;
 
+  @Autowired PractitionerRoleRepository roleRepository;
+  
   static Registration idReg(String type, String pubId, String cdwId) {
     return Registration.builder()
         .uuid(pubId)
@@ -60,6 +63,7 @@ public class Dstu2PractitionerControllerTest {
         new Dstu2Bundler(
             new ConfigurableBaseUrlPageLinks("http://fonzy.com", "cool", "cool", "cool")),
         repository,
+        roleRepository,
         WitnessProtection.builder().identityService(ids).build());
   }
 

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerTransformerTest.java
@@ -62,11 +62,10 @@ public class Dstu2PractitionerTransformerTest {
 
   @Test
   void gender() {
-    Dstu2PractitionerTransformer transformer = Dstu2PractitionerTransformer.builder().build();
-    assertThat(transformer.gender(null)).isNull();
-    assertThat(transformer.gender(DatamartPractitioner.Gender.male))
+    assertThat(Dstu2PractitionerTransformer.gender(null)).isNull();
+    assertThat(Dstu2PractitionerTransformer.gender(DatamartPractitioner.Gender.male))
         .isEqualTo(Practitioner.Gender.male);
-    assertThat(transformer.gender(DatamartPractitioner.Gender.female))
+    assertThat(Dstu2PractitionerTransformer.gender(DatamartPractitioner.Gender.female))
         .isEqualTo(Practitioner.Gender.female);
   }
 

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerTransformerTest.java
@@ -4,6 +4,7 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import gov.va.api.health.dataquery.service.controller.practitionerrole.DatamartPractitionerRole;
+import gov.va.api.health.dataquery.service.controller.practitionerrole.PractitionerRoleSamples;
 import gov.va.api.health.dstu2.api.datatypes.Address;
 import gov.va.api.health.dstu2.api.datatypes.HumanName;
 import gov.va.api.health.dstu2.api.resources.Practitioner;
@@ -99,7 +100,11 @@ public class Dstu2PractitionerTransformerTest {
   @Test
   void practitioner() {
     assertThat(
-            tx(PractitionerSamples.Datamart.create().practitioner("111:S", "222:I", "333:L"))
+            tx(
+                    PractitionerSamples.Datamart.create().practitioner("111:S", "222:I", "333:L"),
+                    List.of(
+                        PractitionerRoleSamples.Datamart.create()
+                            .practitionerRole("111:P", "111:S", "222:I", "333:L")))
                 .toFhir())
         .isEqualTo(PractitionerSamples.Dstu2.create().practitioner("111:S", "222:I", "333:L"));
   }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/Dstu2PractitionerTransformerTest.java
@@ -3,16 +3,19 @@ package gov.va.api.health.dataquery.service.controller.practitioner;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import gov.va.api.health.dataquery.service.controller.practitionerrole.DatamartPractitionerRole;
 import gov.va.api.health.dstu2.api.datatypes.Address;
 import gov.va.api.health.dstu2.api.datatypes.HumanName;
 import gov.va.api.health.dstu2.api.resources.Practitioner;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 public class Dstu2PractitionerTransformerTest {
-  static Dstu2PractitionerTransformer tx(DatamartPractitioner dm) {
-    return Dstu2PractitionerTransformer.builder().datamart(dm).build();
+  static Dstu2PractitionerTransformer tx(
+      DatamartPractitioner dm, List<DatamartPractitionerRole> dmRoles) {
+    return Dstu2PractitionerTransformer.builder().datamart(dm).datamartRoles(dmRoles).build();
   }
 
   @Test
@@ -50,6 +53,7 @@ public class Dstu2PractitionerTransformerTest {
     assertThat(
             Dstu2PractitionerTransformer.builder()
                 .datamart(DatamartPractitioner.builder().build())
+                .datamartRoles(List.of())
                 .build()
                 .toFhir())
         .isEqualTo(Practitioner.builder().build());
@@ -89,7 +93,7 @@ public class Dstu2PractitionerTransformerTest {
   void nullChecks() {
     assertThat(Dstu2PractitionerTransformer.healthcareServices(Optional.empty())).isNull();
     assertThat(Dstu2PractitionerTransformer.telecom(null)).isNull();
-    assertThat(Dstu2PractitionerTransformer.practitionerRole(null)).isNull();
+    assertThat(Dstu2PractitionerTransformer.practitionerRole(null, null)).isNull();
   }
 
   @Test

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/PractitionerSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/PractitionerSamples.java
@@ -101,61 +101,6 @@ public class PractitionerSamples {
                       .build()))
           .gender(DatamartPractitioner.Gender.male)
           .birthDate(Optional.of(LocalDate.parse("1970-11-14")))
-          .practitionerRole(
-              Optional.of(
-                  DatamartPractitioner.PractitionerRole.builder()
-                      .managingOrganization(
-                          Optional.of(
-                              DatamartReference.builder()
-                                  .type(Optional.of("Organization"))
-                                  .reference(Optional.of(orgCdwId))
-                                  .display(Optional.of("SOME VA MEDICAL CENTER"))
-                                  .build()))
-                      .role(
-                          Optional.of(
-                              DatamartCoding.builder()
-                                  .code(Optional.of("1"))
-                                  .display(Optional.of("OPTOMETRIST"))
-                                  .system(Optional.of("rpcmm"))
-                                  .build()))
-                      .specialty(
-                          List.of(
-                              DatamartPractitioner.PractitionerRole.Specialty.builder()
-                                  .providerType(Optional.of("Physicians (M.D. and D.O.)"))
-                                  .classification(Optional.of("Physician/Osteopath"))
-                                  .areaOfSpecialization(Optional.of("Internal Medicine"))
-                                  .vaCode(Optional.of("V111500"))
-                                  .build(),
-                              DatamartPractitioner.PractitionerRole.Specialty.builder()
-                                  .providerType(Optional.of("Physicians (M.D. and D.O.)"))
-                                  .classification(Optional.of("Physician/Osteopath"))
-                                  .areaOfSpecialization(Optional.of("General Practice"))
-                                  .vaCode(Optional.of("V111000"))
-                                  .build(),
-                              DatamartPractitioner.PractitionerRole.Specialty.builder()
-                                  .providerType(Optional.of("Physicians (M.D. and D.O.)"))
-                                  .classification(Optional.of("Physician/Osteopath"))
-                                  .areaOfSpecialization(Optional.of("Family Practice"))
-                                  .vaCode(Optional.of("V110900"))
-                                  .build(),
-                              DatamartPractitioner.PractitionerRole.Specialty.builder()
-                                  .providerType(Optional.of("Allopathic & Osteopathic Physicians"))
-                                  .classification(Optional.of("Family Medicine"))
-                                  .vaCode(Optional.of("V180700"))
-                                  .x12Code(Optional.of("207Q00000X"))
-                                  .build()))
-                      .period(Optional.empty())
-                      .location(
-                          List.of(
-                              DatamartReference.builder()
-                                  .type(Optional.of("Location"))
-                                  .reference(Optional.of(locCdwId))
-                                  .display(
-                                      Optional.of(
-                                          "VISUAL IMPAIRMENT SERVICES OUTPATIENT REHABILITATION (VISOR)"))
-                                  .build()))
-                      .healthCareService(Optional.of("MEDICAL SERVICE"))
-                      .build()))
           .build();
     }
   }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/PractitionerSamples.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitioner/PractitionerSamples.java
@@ -6,8 +6,6 @@ import gov.va.api.health.autoconfig.configuration.JacksonConfig;
 import gov.va.api.health.ids.api.Registration;
 import gov.va.api.health.ids.api.ResourceIdentity;
 import gov.va.api.lighthouse.datamart.CompositeCdwId;
-import gov.va.api.lighthouse.datamart.DatamartCoding;
-import gov.va.api.lighthouse.datamart.DatamartReference;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;


### PR DESCRIPTION
Update `Dstu2PractitionerController` and `Dstu2PractitionerTransformer` to use `DatamartPractitionerRole` and stop using the embedded `DatamartPractitioner.PractitionerRole` class