### PR TITLE
relaxed gender mappings

### DIFF
--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/Dstu2PatientTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/Dstu2PatientTransformer.java
@@ -314,7 +314,7 @@ final class Dstu2PatientTransformer {
     return switch (upperCase(maybeBirthsex, Locale.US)) {
       case "M", "MALE" -> "M";
       case "F", "FEMALE" -> "F";
-      case "*Unknown at this time*", "UNKNOWN" -> "UNK";
+      case "*UNKNOWN AT THIS TIME*", "UNKNOWN" -> "UNK";
       default -> null;
     };
   }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/Dstu2PatientTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/Dstu2PatientTransformer.java
@@ -38,6 +38,7 @@ import lombok.Builder;
 import lombok.NonNull;
 
 @Builder
+@SuppressWarnings("UnnecessaryParentheses")
 final class Dstu2PatientTransformer {
   @NonNull final DatamartPatient datamart;
 
@@ -85,24 +86,13 @@ final class Dstu2PatientTransformer {
     if (telecom == null) {
       return null;
     }
-    switch (upperCase(trimToEmpty(telecom.type()))) {
-      case "PATIENT CELL PHONE":
-        return ContactPoint.ContactPointUse.mobile;
-      case "PATIENT RESIDENCE":
-        // falls through
-      case "PATIENT EMAIL":
-        // falls through
-      case "PATIENT PAGER":
-        return ContactPoint.ContactPointUse.home;
-      case "PATIENT EMPLOYER":
-        // falls through
-      case "SPOUSE EMPLOYER":
-        return ContactPoint.ContactPointUse.work;
-      case "TEMPORARY":
-        return ContactPoint.ContactPointUse.temp;
-      default:
-        return null;
-    }
+    return switch (upperCase(trimToEmpty(telecom.type()))) {
+      case "PATIENT CELL PHONE" -> ContactPointUse.mobile;
+      case "PATIENT RESIDENCE", "PATIENT EMAIL", "PATIENT PAGER" -> ContactPointUse.home;
+      case "PATIENT EMPLOYER", "SPOUSE EMPLOYER" -> ContactPointUse.work;
+      case "TEMPORARY" -> ContactPointUse.temp;
+      default -> null;
+    };
   }
 
   static List<ContactPoint> contactTelecoms(DatamartPatient.Contact.Phone phone) {
@@ -142,14 +132,11 @@ final class Dstu2PatientTransformer {
     if (ethnicity == null) {
       return null;
     }
-    switch (upperCase(trimToEmpty(ethnicity.hl7()), Locale.US)) {
-      case "2135-2":
-        return "Hispanic or Latino";
-      case "2186-5":
-        return "Non Hispanic or Latino";
-      default:
-        return ethnicity.display();
-    }
+    return switch (upperCase(trimToEmpty(ethnicity.hl7()), Locale.US)) {
+      case "2135-2" -> "Hispanic or Latino";
+      case "2186-5" -> "Non Hispanic or Latino";
+      default -> ethnicity.display();
+    };
   }
 
   static List<Extension> ethnicityExtensions(DatamartPatient.Ethnicity ethnicity) {
@@ -180,30 +167,19 @@ final class Dstu2PatientTransformer {
     String upper = upperCase(trimToEmpty(code), Locale.US);
     Coding.CodingBuilder result =
         Coding.builder().system("http://hl7.org/fhir/marital-status").code(upper);
-    switch (upper) {
-      case "A":
-        return result.display("Annulled").build();
-      case "D":
-        return result.display("Divorced").build();
-      case "I":
-        return result.display("Interlocutory").build();
-      case "L":
-        return result.display("Legally Separated").build();
-      case "M":
-        return result.display("Married").build();
-      case "P":
-        return result.display("Polygamous").build();
-      case "S":
-        return result.display("Never Married").build();
-      case "T":
-        return result.display("Domestic partner").build();
-      case "W":
-        return result.display("Widowed").build();
-      case "UNK":
-        return result.system("http://hl7.org/fhir/v3/NullFlavor").display("unknown").build();
-      default:
-        return null;
-    }
+    return switch (upper) {
+      case "A" -> result.display("Annulled").build();
+      case "D" -> result.display("Divorced").build();
+      case "I" -> result.display("Interlocutory").build();
+      case "L" -> result.display("Legally Separated").build();
+      case "M" -> result.display("Married").build();
+      case "P" -> result.display("Polygamous").build();
+      case "S" -> result.display("Never Married").build();
+      case "T" -> result.display("Domestic partner").build();
+      case "W" -> result.display("Widowed").build();
+      case "UNK" -> result.system("http://hl7.org/fhir/v3/NullFlavor").display("unknown").build();
+      default -> null;
+    };
   }
 
   static HumanName name(DatamartPatient.Contact contact) {
@@ -269,24 +245,18 @@ final class Dstu2PatientTransformer {
     }
     Coding.CodingBuilder builder =
         Coding.builder().system("http://hl7.org/fhir/patient-contact-relationship");
-    switch (upperCase(trimToEmpty(contact.type()), Locale.US)) {
-      case "CIVIL GUARDIAN":
-        // falls through
-      case "VA GUARDIAN":
-        return builder.code("guardian").display("Guardian").build();
-      case "EMERGENCY CONTACT":
-        // falls through
-      case "SECONDARY EMERGENCY CONTACT":
-        return builder.code("emergency").display("Emergency").build();
-      case "NEXT OF KIN":
-        // falls through
-      case "SECONDARY NEXT OF KIN":
-        // falls through
-      case "SPOUSE EMPLOYER":
-        return builder.code("family").display("Family").build();
-      default:
-        return null;
-    }
+    return switch (upperCase(trimToEmpty(contact.type()), Locale.US)) {
+      case "CIVIL GUARDIAN", "VA GUARDIAN" -> builder.code("guardian").display("Guardian").build();
+      case "EMERGENCY CONTACT", "SECONDARY EMERGENCY CONTACT" -> builder
+          .code("emergency")
+          .display("Emergency")
+          .build();
+      case "NEXT OF KIN", "SECONDARY NEXT OF KIN", "SPOUSE EMPLOYER" -> builder
+          .code("family")
+          .display("Family")
+          .build();
+      default -> null;
+    };
   }
 
   static List<CodeableConcept> relationships(DatamartPatient.Contact contact) {
@@ -304,20 +274,14 @@ final class Dstu2PatientTransformer {
     if (use == null) {
       return 6;
     }
-    switch (use) {
-      case mobile:
-        return 1;
-      case home:
-        return 2;
-      case temp:
-        return 3;
-      case work:
-        return 4;
-      case old:
-        return 5;
-      default:
-        return 6;
-    }
+    return switch (use) {
+      case mobile -> 1;
+      case home -> 2;
+      case temp -> 3;
+      case work -> 4;
+      case old -> 5;
+      default -> 6;
+    };
   }
 
   private static String stripPhone(String phone) {
@@ -347,16 +311,12 @@ final class Dstu2PatientTransformer {
     if (isBlank(maybeBirthsex)) {
       return null;
     }
-    switch (maybeBirthsex) {
-      case "M":
-        return "M";
-      case "F":
-        return "F";
-      case "*Unknown at this time*":
-        return "UNK";
-      default:
-        return null;
-    }
+    return switch (upperCase(maybeBirthsex, Locale.US)) {
+      case "M", "MALE" -> "M";
+      case "F", "FEMALE" -> "F";
+      case "*Unknown at this time*", "UNKNOWN" -> "UNK";
+      default -> null;
+    };
   }
 
   private List<Patient.Contact> contacts() {
@@ -368,14 +328,11 @@ final class Dstu2PatientTransformer {
     if (deceasedDateTime() != null) {
       return null;
     }
-    switch (upperCase(trimToEmpty(datamart.deceased()), Locale.US)) {
-      case "Y":
-        return true;
-      case "N":
-        return false;
-      default:
-        return null;
-    }
+    return switch (upperCase(trimToEmpty(datamart.deceased()), Locale.US)) {
+      case "Y" -> true;
+      case "N" -> false;
+      default -> null;
+    };
   }
 
   private String deceasedDateTime() {
@@ -419,10 +376,10 @@ final class Dstu2PatientTransformer {
   }
 
   private Patient.Gender gender() {
-    if (isBlank(datamart.gender())) {
-      return null;
+    if (isNotBlank(datamart.gender())) {
+      return GenderMapping.toDstu2Fhir(datamart.gender());
     }
-    return GenderMapping.toDstu2Fhir(datamart.gender());
+    return Patient.Gender.unknown;
   }
 
   private List<Identifier> identifiers() {

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/GenderMapping.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/GenderMapping.java
@@ -6,50 +6,36 @@ import java.util.Locale;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
+@SuppressWarnings("UnnecessaryParentheses")
 class GenderMapping {
 
   String toCdw(String fhir) {
-    switch (upperCase(fhir, Locale.US)) {
-      case "MALE":
-        return "M";
-      case "FEMALE":
-        return "F";
-      case "OTHER":
-        return "*Missing*";
-      case "UNKNOWN":
-        return "*Unknown at this time*";
-      default:
-        return null;
-    }
+    return switch (upperCase(fhir, Locale.US)) {
+      case "MALE" -> "M";
+      case "FEMALE" -> "F";
+      case "OTHER" -> "*Missing*";
+      case "UNKNOWN" -> "*Unknown at this time*";
+      default -> null;
+    };
   }
 
   gov.va.api.health.dstu2.api.resources.Patient.Gender toDstu2Fhir(String cdw) {
-    switch (upperCase(cdw, Locale.US)) {
-      case "M":
-        return gov.va.api.health.dstu2.api.resources.Patient.Gender.male;
-      case "F":
-        return gov.va.api.health.dstu2.api.resources.Patient.Gender.female;
-      case "*MISSING*":
-        return gov.va.api.health.dstu2.api.resources.Patient.Gender.other;
-      case "*UNKNOWN AT THIS TIME*":
-        return gov.va.api.health.dstu2.api.resources.Patient.Gender.unknown;
-      default:
-        return null;
-    }
+    return switch (upperCase(cdw, Locale.US)) {
+      case "M", "MALE" -> gov.va.api.health.dstu2.api.resources.Patient.Gender.male;
+      case "F", "FEMALE" -> gov.va.api.health.dstu2.api.resources.Patient.Gender.female;
+      case "*UNKNOWN AT THIS TIME*", "UNKNOWN", "DOES NOT WISH TO DISCLOSE" -> gov.va.api.health
+          .dstu2.api.resources.Patient.Gender.unknown;
+      default -> gov.va.api.health.dstu2.api.resources.Patient.Gender.other;
+    };
   }
 
   gov.va.api.health.r4.api.resources.Patient.Gender toR4Fhir(String cdw) {
-    switch (upperCase(cdw, Locale.US)) {
-      case "M":
-        return gov.va.api.health.r4.api.resources.Patient.Gender.male;
-      case "F":
-        return gov.va.api.health.r4.api.resources.Patient.Gender.female;
-      case "*MISSING*":
-        return gov.va.api.health.r4.api.resources.Patient.Gender.other;
-      case "*UNKNOWN AT THIS TIME*":
-        return gov.va.api.health.r4.api.resources.Patient.Gender.unknown;
-      default:
-        return null;
-    }
+    return switch (upperCase(cdw, Locale.US)) {
+      case "M", "MALE" -> gov.va.api.health.r4.api.resources.Patient.Gender.male;
+      case "F", "FEMALE" -> gov.va.api.health.r4.api.resources.Patient.Gender.female;
+      case "*UNKNOWN AT THIS TIME*", "UNKNOWN", "DOES NOT WISH TO DISCLOSE" -> gov.va.api.health.r4
+          .api.resources.Patient.Gender.unknown;
+      default -> gov.va.api.health.r4.api.resources.Patient.Gender.other;
+    };
   }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/R4PatientTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/R4PatientTransformer.java
@@ -318,7 +318,7 @@ final class R4PatientTransformer {
     return switch (upperCase(maybeBirthsex, Locale.US)) {
       case "M", "MALE" -> "M";
       case "F", "FEMALE" -> "F";
-      case "*Unknown at this time*", "UNKNOWN" -> "UNK";
+      case "*UNKNOWN AT THIS TIME*", "UNKNOWN" -> "UNK";
       default -> null;
     };
   }
@@ -382,7 +382,8 @@ final class R4PatientTransformer {
   private Patient.Gender gender() {
     var badSelfIdentifiedGenders = List.of("NULL", "*Unknown at this time*", "*Missing*");
     if (datamart.selfIdentifiedGender().isPresent()
-        && !badSelfIdentifiedGenders.contains(datamart.selfIdentifiedGender().get())) {
+        && !badSelfIdentifiedGenders.stream()
+            .anyMatch(bads -> containsIgnoreCase(bads, datamart.selfIdentifiedGender().get()))) {
       return GenderMapping.toR4Fhir(datamart.selfIdentifiedGender().get());
     } else if (isNotBlank(datamart.gender())) {
       return GenderMapping.toR4Fhir(datamart.gender());

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/R4PatientTransformer.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/patient/R4PatientTransformer.java
@@ -36,8 +36,8 @@ import java.util.Set;
 import lombok.Builder;
 import lombok.NonNull;
 
-@SuppressWarnings("EnhancedSwitchMigration")
 @Builder
+@SuppressWarnings("UnnecessaryParentheses")
 final class R4PatientTransformer {
   @NonNull private final DatamartPatient datamart;
 
@@ -85,24 +85,14 @@ final class R4PatientTransformer {
     if (telecom == null) {
       return null;
     }
-    switch (upperCase(trimToEmpty(telecom.type()))) {
-      case "PATIENT CELL PHONE":
-        return ContactPoint.ContactPointUse.mobile;
-      case "PATIENT RESIDENCE":
-        // falls through
-      case "PATIENT EMAIL":
-        // falls through
-      case "PATIENT PAGER":
-        return ContactPoint.ContactPointUse.home;
-      case "PATIENT EMPLOYER":
-        // falls through
-      case "SPOUSE EMPLOYER":
-        return ContactPoint.ContactPointUse.work;
-      case "TEMPORARY":
-        return ContactPoint.ContactPointUse.temp;
-      default:
-        return null;
-    }
+    return switch (upperCase(trimToEmpty(telecom.type()))) {
+      case "PATIENT CELL PHONE" -> ContactPoint.ContactPointUse.mobile;
+      case "PATIENT RESIDENCE", "PATIENT EMAIL", "PATIENT PAGER" -> ContactPoint.ContactPointUse
+          .home;
+      case "PATIENT EMPLOYER", "SPOUSE EMPLOYER" -> ContactPoint.ContactPointUse.work;
+      case "TEMPORARY" -> ContactPoint.ContactPointUse.temp;
+      default -> null;
+    };
   }
 
   static List<ContactPoint> contactTelecoms(DatamartPatient.Contact.Phone phone) {
@@ -142,14 +132,11 @@ final class R4PatientTransformer {
     if (ethnicity == null) {
       return null;
     }
-    switch (upperCase(trimToEmpty(ethnicity.hl7()), Locale.US)) {
-      case "2135-2":
-        return "Hispanic or Latino";
-      case "2186-5":
-        return "Non Hispanic or Latino";
-      default:
-        return ethnicity.display();
-    }
+    return switch (upperCase(trimToEmpty(ethnicity.hl7()), Locale.US)) {
+      case "2135-2" -> "Hispanic or Latino";
+      case "2186-5" -> "Non Hispanic or Latino";
+      default -> ethnicity.display();
+    };
   }
 
   static List<Extension> ethnicityExtensions(DatamartPatient.Ethnicity ethnicity) {
@@ -180,30 +167,22 @@ final class R4PatientTransformer {
     String upper = upperCase(trimToEmpty(code), Locale.US);
     Coding.CodingBuilder result =
         Coding.builder().system("http://hl7.org/fhir/marital-status").code(upper);
-    switch (upper) {
-      case "A":
-        return result.display("Annulled").build();
-      case "D":
-        return result.display("Divorced").build();
-      case "I":
-        return result.display("Interlocutory").build();
-      case "L":
-        return result.display("Legally Separated").build();
-      case "M":
-        return result.display("Married").build();
-      case "P":
-        return result.display("Polygamous").build();
-      case "S":
-        return result.display("Never Married").build();
-      case "T":
-        return result.display("Domestic partner").build();
-      case "W":
-        return result.display("Widowed").build();
-      case "UNK":
-        return result.system("http://hl7.org/fhir/R4/v3/NullFlavor").display("unknown").build();
-      default:
-        return null;
-    }
+    return switch (upper) {
+      case "A" -> result.display("Annulled").build();
+      case "D" -> result.display("Divorced").build();
+      case "I" -> result.display("Interlocutory").build();
+      case "L" -> result.display("Legally Separated").build();
+      case "M" -> result.display("Married").build();
+      case "P" -> result.display("Polygamous").build();
+      case "S" -> result.display("Never Married").build();
+      case "T" -> result.display("Domestic partner").build();
+      case "W" -> result.display("Widowed").build();
+      case "UNK" -> result
+          .system("http://hl7.org/fhir/R4/v3/NullFlavor")
+          .display("unknown")
+          .build();
+      default -> null;
+    };
   }
 
   static HumanName name(DatamartPatient.Contact contact) {
@@ -270,24 +249,18 @@ final class R4PatientTransformer {
     }
     Coding.CodingBuilder builder =
         Coding.builder().system("http://hl7.org/fhir/patient-contact-relationship");
-    switch (upperCase(trimToEmpty(contact.type()), Locale.US)) {
-      case "CIVIL GUARDIAN":
-        // falls through
-      case "VA GUARDIAN":
-        return builder.code("guardian").display("Guardian").build();
-      case "EMERGENCY CONTACT":
-        // falls through
-      case "SECONDARY EMERGENCY CONTACT":
-        return builder.code("emergency").display("Emergency").build();
-      case "NEXT OF KIN":
-        // falls through
-      case "SECONDARY NEXT OF KIN":
-        // falls through
-      case "SPOUSE EMPLOYER":
-        return builder.code("family").display("Family").build();
-      default:
-        return null;
-    }
+    return switch (upperCase(trimToEmpty(contact.type()), Locale.US)) {
+      case "CIVIL GUARDIAN", "VA GUARDIAN" -> builder.code("guardian").display("Guardian").build();
+      case "EMERGENCY CONTACT", "SECONDARY EMERGENCY CONTACT" -> builder
+          .code("emergency")
+          .display("Emergency")
+          .build();
+      case "NEXT OF KIN", "SECONDARY NEXT OF KIN", "SPOUSE EMPLOYER" -> builder
+          .code("family")
+          .display("Family")
+          .build();
+      default -> null;
+    };
   }
 
   static List<CodeableConcept> relationships(DatamartPatient.Contact contact) {
@@ -305,20 +278,14 @@ final class R4PatientTransformer {
     if (use == null) {
       return 6;
     }
-    switch (use) {
-      case mobile:
-        return 1;
-      case home:
-        return 2;
-      case temp:
-        return 3;
-      case work:
-        return 4;
-      case old:
-        return 5;
-      default:
-        return 6;
-    }
+    return switch (use) {
+      case mobile -> 1;
+      case home -> 2;
+      case temp -> 3;
+      case work -> 4;
+      case old -> 5;
+      default -> 6;
+    };
   }
 
   private static String stripPhone(String phone) {
@@ -348,16 +315,12 @@ final class R4PatientTransformer {
     if (isBlank(maybeBirthsex)) {
       return null;
     }
-    switch (maybeBirthsex) {
-      case "M":
-        return "M";
-      case "F":
-        return "F";
-      case "*Unknown at this time*":
-        return "UNK";
-      default:
-        return null;
-    }
+    return switch (upperCase(maybeBirthsex, Locale.US)) {
+      case "M", "MALE" -> "M";
+      case "F", "FEMALE" -> "F";
+      case "*Unknown at this time*", "UNKNOWN" -> "UNK";
+      default -> null;
+    };
   }
 
   private List<Patient.PatientContact> contacts() {
@@ -369,14 +332,11 @@ final class R4PatientTransformer {
     if (deceasedDateTime() != null) {
       return null;
     }
-    switch (upperCase(trimToEmpty(datamart.deceased()), Locale.US)) {
-      case "Y":
-        return true;
-      case "N":
-        return false;
-      default:
-        return null;
-    }
+    return switch (upperCase(trimToEmpty(datamart.deceased()), Locale.US)) {
+      case "Y" -> true;
+      case "N" -> false;
+      default -> null;
+    };
   }
 
   private String deceasedDateTime() {
@@ -420,12 +380,14 @@ final class R4PatientTransformer {
   }
 
   private Patient.Gender gender() {
-    if (datamart.selfIdentifiedGender() != null && datamart.selfIdentifiedGender().isPresent()) {
+    var badSelfIdentifiedGenders = List.of("NULL", "*Unknown at this time*", "*Missing*");
+    if (datamart.selfIdentifiedGender().isPresent()
+        && !badSelfIdentifiedGenders.contains(datamart.selfIdentifiedGender().get())) {
       return GenderMapping.toR4Fhir(datamart.selfIdentifiedGender().get());
     } else if (isNotBlank(datamart.gender())) {
       return GenderMapping.toR4Fhir(datamart.gender());
     } else {
-      return null;
+      return Patient.Gender.unknown;
     }
   }
 

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/Dstu2PatientTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/Dstu2PatientTransformerTest.java
@@ -13,6 +13,7 @@ public class Dstu2PatientTransformerTest {
                 .datamart(DatamartPatient.builder().build())
                 .build()
                 .toFhir())
-        .isEqualTo(Patient.builder().resourceType("Patient").build());
+        .isEqualTo(
+            Patient.builder().resourceType("Patient").gender(Patient.Gender.unknown).build());
   }
 }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/Dstu2PatientTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/Dstu2PatientTransformerTest.java
@@ -1,19 +1,36 @@
 package gov.va.api.health.dataquery.service.controller.patient;
 
+import static gov.va.api.health.dstu2.api.resources.Patient.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import gov.va.api.health.dstu2.api.resources.Patient;
 import org.junit.jupiter.api.Test;
 
 public class Dstu2PatientTransformerTest {
   @Test
-  public void empty() {
+  void empty() {
     assertThat(
             Dstu2PatientTransformer.builder()
                 .datamart(DatamartPatient.builder().build())
                 .build()
                 .toFhir())
-        .isEqualTo(
-            Patient.builder().resourceType("Patient").gender(Patient.Gender.unknown).build());
+        .isEqualTo(builder().resourceType("Patient").gender(Gender.unknown).build());
+  }
+
+  @Test
+  void gender() {
+    assertThat(genderOf("M")).isEqualTo(Gender.male);
+    assertThat(genderOf("F")).isEqualTo(Gender.female);
+    assertThat(genderOf("unknown")).isEqualTo(Gender.unknown);
+    assertThat(genderOf("female")).isEqualTo(Gender.female);
+    assertThat(genderOf(null)).isEqualTo(Gender.unknown);
+    assertThat(genderOf("shanktopus")).isEqualTo(Gender.other);
+  }
+
+  private Gender genderOf(String birthGender) {
+    return Dstu2PatientTransformer.builder()
+        .datamart(DatamartPatient.builder().gender(birthGender).build())
+        .build()
+        .toFhir()
+        .gender();
   }
 }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/GenderMappingTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/GenderMappingTest.java
@@ -24,14 +24,21 @@ public class GenderMappingTest {
   public void genderMappingToDstu2FhirIsValid() {
     assertThat(GenderMapping.toDstu2Fhir("M")).isEqualTo(Patient.Gender.male);
     assertThat(GenderMapping.toDstu2Fhir("m")).isEqualTo(Patient.Gender.male);
+    assertThat(GenderMapping.toDstu2Fhir("malE")).isEqualTo(Patient.Gender.male);
+
     assertThat(GenderMapping.toDstu2Fhir("F")).isEqualTo(Patient.Gender.female);
-    assertThat(GenderMapping.toDstu2Fhir("*MISSING*")).isEqualTo(Patient.Gender.other);
-    assertThat(GenderMapping.toDstu2Fhir("*mIssIng*")).isEqualTo(Patient.Gender.other);
+    assertThat(GenderMapping.toDstu2Fhir("f")).isEqualTo(Patient.Gender.female);
+    assertThat(GenderMapping.toDstu2Fhir("feMale")).isEqualTo(Patient.Gender.female);
+
     assertThat(GenderMapping.toDstu2Fhir("*UNKNOWN AT THIS TIME*"))
         .isEqualTo(Patient.Gender.unknown);
-    assertThat(GenderMapping.toDstu2Fhir("-UNKNOWN AT THIS TIME-")).isNull();
-    assertThat(GenderMapping.toDstu2Fhir("")).isNull();
-    assertThat(GenderMapping.toDstu2Fhir("male")).isNull();
+    assertThat(GenderMapping.toDstu2Fhir("unknowN")).isEqualTo(Patient.Gender.unknown);
+
+    assertThat(GenderMapping.toDstu2Fhir("-UNKNOWN AT THIS TIME-")).isEqualTo(Patient.Gender.other);
+    assertThat(GenderMapping.toDstu2Fhir("*MISSING*")).isEqualTo(Patient.Gender.other);
+    assertThat(GenderMapping.toDstu2Fhir("TRanSGENDeR Male")).isEqualTo(Patient.Gender.other);
+    assertThat(GenderMapping.toDstu2Fhir("*mIssIng*")).isEqualTo(Patient.Gender.other);
+    assertThat(GenderMapping.toDstu2Fhir("shanktopus")).isEqualTo(Patient.Gender.other);
   }
 
   @Test
@@ -40,16 +47,32 @@ public class GenderMappingTest {
         .isEqualTo(gov.va.api.health.r4.api.resources.Patient.Gender.male);
     assertThat(GenderMapping.toR4Fhir("m"))
         .isEqualTo(gov.va.api.health.r4.api.resources.Patient.Gender.male);
+    assertThat(GenderMapping.toR4Fhir("maLe"))
+        .isEqualTo(gov.va.api.health.r4.api.resources.Patient.Gender.male);
+
     assertThat(GenderMapping.toR4Fhir("F"))
         .isEqualTo(gov.va.api.health.r4.api.resources.Patient.Gender.female);
+    assertThat(GenderMapping.toR4Fhir("f"))
+        .isEqualTo(gov.va.api.health.r4.api.resources.Patient.Gender.female);
+    assertThat(GenderMapping.toR4Fhir("feMale"))
+        .isEqualTo(gov.va.api.health.r4.api.resources.Patient.Gender.female);
+
+    assertThat(GenderMapping.toR4Fhir("*UNKNOWN AT THIS TIME*"))
+        .isEqualTo(gov.va.api.health.r4.api.resources.Patient.Gender.unknown);
+    assertThat(GenderMapping.toR4Fhir("unkNown"))
+        .isEqualTo(gov.va.api.health.r4.api.resources.Patient.Gender.unknown);
+    assertThat(GenderMapping.toR4Fhir("Does not wish to disclose"))
+        .isEqualTo(gov.va.api.health.r4.api.resources.Patient.Gender.unknown);
+
+    assertThat(GenderMapping.toR4Fhir("-UNKNOWN AT THIS TIME-"))
+        .isEqualTo(gov.va.api.health.r4.api.resources.Patient.Gender.other);
     assertThat(GenderMapping.toR4Fhir("*MISSING*"))
         .isEqualTo(gov.va.api.health.r4.api.resources.Patient.Gender.other);
     assertThat(GenderMapping.toR4Fhir("*mIssIng*"))
         .isEqualTo(gov.va.api.health.r4.api.resources.Patient.Gender.other);
-    assertThat(GenderMapping.toR4Fhir("*UNKNOWN AT THIS TIME*"))
-        .isEqualTo(gov.va.api.health.r4.api.resources.Patient.Gender.unknown);
-    assertThat(GenderMapping.toR4Fhir("-UNKNOWN AT THIS TIME-")).isNull();
-    assertThat(GenderMapping.toR4Fhir("")).isNull();
-    assertThat(GenderMapping.toR4Fhir("male")).isNull();
+    assertThat(GenderMapping.toR4Fhir("TRANsGENder Male"))
+        .isEqualTo(gov.va.api.health.r4.api.resources.Patient.Gender.other);
+    assertThat(GenderMapping.toR4Fhir("shanktopus"))
+        .isEqualTo(gov.va.api.health.r4.api.resources.Patient.Gender.other);
   }
 }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/R4PatientTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/R4PatientTransformerTest.java
@@ -77,6 +77,8 @@ public class R4PatientTransformerTest {
     assertThat(genderOf("M", Optional.of("MaLE"))).isEqualTo(Patient.Gender.male);
     assertThat(genderOf("F", Optional.of("feMALE"))).isEqualTo(Patient.Gender.female);
     assertThat(genderOf("male", Optional.of("feMALE"))).isEqualTo(Patient.Gender.female);
+    assertThat(genderOf("female", Optional.of("*UNKNOWN AT THIS TIME*")))
+        .isEqualTo(Patient.Gender.female);
     assertThat(genderOf("unknown", Optional.of("NULL"))).isEqualTo(Patient.Gender.unknown);
     assertThat(genderOf("female", Optional.of("TransgedER MALE"))).isEqualTo(Patient.Gender.other);
     assertThat(genderOf(null, Optional.empty())).isEqualTo(Patient.Gender.unknown);

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/R4PatientTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/R4PatientTransformerTest.java
@@ -14,24 +14,25 @@ import org.junit.jupiter.api.Test;
 
 public class R4PatientTransformerTest {
   @Test
-  public void contact() {
+  void contact() {
     Datamart datamart = Datamart.create();
     R4 r4 = R4.create();
     assertThat(R4PatientTransformer.contact(datamart.contact())).isEqualTo(r4.contact());
   }
 
   @Test
-  public void empty() {
+  void empty() {
     assertThat(
             R4PatientTransformer.builder()
                 .datamart(DatamartPatient.builder().build())
                 .build()
                 .toFhir())
-        .isEqualTo(Patient.builder().resourceType("Patient").build());
+        .isEqualTo(
+            Patient.builder().resourceType("Patient").gender(Patient.Gender.unknown).build());
   }
 
   @Test
-  public void ethnicityDisplay() {
+  void ethnicityDisplay() {
     assertThat(
             R4PatientTransformer.ethnicityDisplay(
                 DatamartPatient.Ethnicity.builder().hl7("2135-2").display("hi").build()))
@@ -52,7 +53,7 @@ public class R4PatientTransformerTest {
   }
 
   @Test
-  public void ethnicityExtensions() {
+  void ethnicityExtensions() {
     assertThat(
             R4PatientTransformer.ethnicityExtensions(
                 DatamartPatient.Ethnicity.builder().display("display").hl7("code").build()))
@@ -72,7 +73,7 @@ public class R4PatientTransformerTest {
   }
 
   @Test
-  public void managingOrganization() {
+  void managingOrganization() {
     assertThat(
             R4PatientTransformer.builder()
                 .datamart(Datamart.create().patient().managingOrganization(Optional.empty()))
@@ -98,7 +99,7 @@ public class R4PatientTransformerTest {
   }
 
   @Test
-  public void maritalStatus() {
+  void maritalStatus() {
     assertThat(R4PatientTransformer.maritalStatusCoding("A").display()).isEqualTo("Annulled");
     assertThat(R4PatientTransformer.maritalStatusCoding("D").display()).isEqualTo("Divorced");
     assertThat(R4PatientTransformer.maritalStatusCoding("I").display()).isEqualTo("Interlocutory");
@@ -115,7 +116,7 @@ public class R4PatientTransformerTest {
   }
 
   @Test
-  public void raceCoding() {
+  void raceCoding() {
     assertThat(
             R4PatientTransformer.raceCoding(
                     DatamartPatient.Race.builder().display("Alaska Native").build())
@@ -163,7 +164,7 @@ public class R4PatientTransformerTest {
   }
 
   @Test
-  public void relationshipCoding() {
+  void relationshipCoding() {
     assertThat(
             R4PatientTransformer.relationshipCoding(
                     DatamartPatient.Contact.builder().type("Civil Guardian").build())
@@ -206,7 +207,7 @@ public class R4PatientTransformerTest {
   }
 
   @Test
-  public void toFhir() {
+  void toFhir() {
     assertThat(
             R4PatientTransformer.builder().datamart(Datamart.create().patient()).build().toFhir())
         .isEqualTo(R4.create().patient());

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/R4PatientTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/R4PatientTransformerTest.java
@@ -73,6 +73,27 @@ public class R4PatientTransformerTest {
   }
 
   @Test
+  void gender() {
+    assertThat(genderOf("M", Optional.of("MaLE"))).isEqualTo(Patient.Gender.male);
+    assertThat(genderOf("F", Optional.of("feMALE"))).isEqualTo(Patient.Gender.female);
+    assertThat(genderOf("unknown", Optional.of("NULL"))).isEqualTo(Patient.Gender.unknown);
+    assertThat(genderOf("female", Optional.of("TransgedER MALE"))).isEqualTo(Patient.Gender.other);
+    assertThat(genderOf(null, Optional.empty())).isEqualTo(Patient.Gender.unknown);
+  }
+
+  private Patient.Gender genderOf(String birthGender, Optional<String> selfIdentifiedGender) {
+    return R4PatientTransformer.builder()
+        .datamart(
+            DatamartPatient.builder()
+                .gender(birthGender)
+                .selfIdentifiedGender(selfIdentifiedGender)
+                .build())
+        .build()
+        .toFhir()
+        .gender();
+  }
+
+  @Test
   void managingOrganization() {
     assertThat(
             R4PatientTransformer.builder()

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/R4PatientTransformerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/patient/R4PatientTransformerTest.java
@@ -76,6 +76,7 @@ public class R4PatientTransformerTest {
   void gender() {
     assertThat(genderOf("M", Optional.of("MaLE"))).isEqualTo(Patient.Gender.male);
     assertThat(genderOf("F", Optional.of("feMALE"))).isEqualTo(Patient.Gender.female);
+    assertThat(genderOf("male", Optional.of("feMALE"))).isEqualTo(Patient.Gender.female);
     assertThat(genderOf("unknown", Optional.of("NULL"))).isEqualTo(Patient.Gender.unknown);
     assertThat(genderOf("female", Optional.of("TransgedER MALE"))).isEqualTo(Patient.Gender.other);
     assertThat(genderOf(null, Optional.empty())).isEqualTo(Patient.Gender.unknown);


### PR DESCRIPTION
Refactored some switch statements for less lines of code.
Note: I had to `@SuppressWarnings(UnneccessaryParenthesis)` for the new switches, error prone is being dumb.

Added more relaxed gender mappings for both dstu2 and r4 patient, and supporting unit tests.

Mappings : https://vajira.max.gov/browse/API-8340?workflowName=Lighthouse+Default+Workflow&stepId=8