### PR TITLE
API-8343 practitioner role search by specialty

### DIFF
--- a/data-query-tests/src/main/java/gov/va/api/health/dataquery/tests/SystemDefinitions.java
+++ b/data-query-tests/src/main/java/gov/va/api/health/dataquery/tests/SystemDefinitions.java
@@ -143,7 +143,7 @@ public final class SystemDefinitions {
         .family("DOE922")
         .given("JANE460")
         .npi("1932127842")
-        .specialty("http://hl7.org/fhir/practitioner-specialty|207Q00000X")
+        .specialty("207Q00000X")
         .build();
   }
 
@@ -313,7 +313,7 @@ public final class SystemDefinitions {
         .family("ACOSTA")
         .given("SAID")
         .npi("1013904481")
-        .specialty("http://hl7.org/fhir/practitioner-specialty|xxx")
+        .specialty("367500000X")
         .build();
   }
 

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerRoleIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerRoleIT.java
@@ -151,6 +151,23 @@ public class PractitionerRoleIT {
             PractitionerRole.Bundle.class,
             bundleHasResults().negate(),
             "PractitionerRole?specialty={code}",
-            testIds.unknown()));
+            testIds.unknown()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults().negate(),
+            "PractitionerRole?specialty=unknown-system|{code}",
+            testIds.practitioners().specialty()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults().negate(),
+            "PractitionerRole?specialty=|{code}",
+            testIds.practitioners().specialty()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults().negate(),
+            "PractitionerRole?specialty=http://nucc.org/provider-taxonomy|"));
   }
 }

--- a/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerRoleIT.java
+++ b/data-query-tests/src/test/java/gov/va/api/health/dataquery/tests/r4/PractitionerRoleIT.java
@@ -130,4 +130,27 @@ public class PractitionerRoleIT {
             "PractitionerRole?practitioner.identifier=|{npi}",
             testIds.unknown()));
   }
+
+  @Test
+  void searchBySpecialty() {
+    verifyAll(
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults(),
+            "PractitionerRole?specialty=http://nucc.org/provider-taxonomy|{code}",
+            testIds.practitioners().specialty()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults(),
+            "PractitionerRole?specialty={code}",
+            testIds.practitioners().specialty()),
+        test(
+            200,
+            PractitionerRole.Bundle.class,
+            bundleHasResults().negate(),
+            "PractitionerRole?specialty={code}",
+            testIds.unknown()));
+  }
 }

--- a/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitionerrole/PractitionerRoleRepository.java
+++ b/data-query/src/main/java/gov/va/api/health/dataquery/service/controller/practitionerrole/PractitionerRoleRepository.java
@@ -4,8 +4,16 @@ import gov.va.api.health.autoconfig.logging.Loggable;
 import gov.va.api.lighthouse.datamart.CompositeCdwId;
 import java.math.BigInteger;
 import java.util.List;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Subquery;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.transaction.annotation.Isolation;
@@ -23,4 +31,39 @@ public interface PractitionerRoleRepository
 
   List<PractitionerRoleEntity> findByPractitionerIdNumberAndPractitionerResourceCode(
       BigInteger idNumber, char practitionerResourceCode);
+
+  @Value
+  @RequiredArgsConstructor(staticName = "of")
+  class SpecialtySpecification implements Specification<PractitionerRoleEntity> {
+    String code;
+
+    private Subquery<Boolean> specialtyMapSubquery(
+        Root<PractitionerRoleEntity> root,
+        CriteriaQuery<?> criteriaQuery,
+        CriteriaBuilder criteriaBuilder) {
+      var subquery = criteriaQuery.subquery(Boolean.class);
+      var subqueryRoot = subquery.from(PractitionerRoleSpecialtyMapEntity.class);
+      subquery.select(criteriaBuilder.literal(true));
+      var predicateSpecialtyCode = criteriaBuilder.equal(subqueryRoot.get("specialtyCode"), code);
+      var predicateCdwId =
+          criteriaBuilder.equal(
+              subqueryRoot.get("practitionerRoleIdNumber"), root.get("cdwIdNumber"));
+      var predicateCdwResourceCode =
+          criteriaBuilder.equal(
+              subqueryRoot.get("practitionerRoleResourceCode"), root.get("cdwIdResourceCode"));
+      subquery.where(
+          criteriaBuilder.and(predicateSpecialtyCode, predicateCdwId, predicateCdwResourceCode));
+      return subquery;
+    }
+
+    @Override
+    public Predicate toPredicate(
+        Root<PractitionerRoleEntity> root,
+        CriteriaQuery<?> criteriaQuery,
+        CriteriaBuilder criteriaBuilder) {
+      Predicate roleIsActive = criteriaBuilder.equal(root.get("active"), true);
+      Subquery<Boolean> subquery = specialtyMapSubquery(root, criteriaQuery, criteriaBuilder);
+      return criteriaBuilder.and(roleIsActive, criteriaBuilder.exists(subquery));
+    }
+  }
 }

--- a/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitionerrole/R4PractitionerRoleControllerTest.java
+++ b/data-query/src/test/java/gov/va/api/health/dataquery/service/controller/practitionerrole/R4PractitionerRoleControllerTest.java
@@ -217,6 +217,8 @@ public class R4PractitionerRoleControllerTest {
         "?practitioner.identifier=http://hl7.org/fhir/sid/us-npi|",
         "?practitioner.identifier=http://hl7.org/fhir/sid/us-npi|123",
         "?practitioner.name=harry",
+        "?specialty=ABC123",
+        "?specialty=http://nucc.org/provider-taxonomy|ABC123"
       })
   void validRequests(String query) {
     _registerMockIdentities(


### PR DESCRIPTION
Adds `specialty` search param to R4 PractitionerRole

Examples:
```
/r4/PractitionerRole?specialty=207Q00000X
/r4/PractitionerRole?specialty=http://nucc.org/provider-taxonomy|207Q00000X
```
